### PR TITLE
fix: Dockerfile 빌드 경로 수정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY go.mod go.sum* ./
 RUN go mod download
 COPY . .
-RUN go build -o server ./cmd/server
+RUN go build -o server ./cmd/api
 
 FROM alpine:3.20
 WORKDIR /app


### PR DESCRIPTION
cmd/server에서 cmd/api로 변경

GitHub Actions 빌드 실패 원인:
- main.go 위치: backend/cmd/api/main.go
- Dockerfile 빌드 명령: ./cmd/server (잘못된 경로)

이 PR이 빌드 실패를 해결합니다.