### PR TITLE
feat: docker-compose 환경변수 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       - SERVER_PORT=8080
       - SERVER_IP=${SERVER_IP}
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
       - REDIS_URL=redis://redis:6379
       - JWT_SECRET=${JWT_SECRET}
       - ENVIRONMENT=production


### PR DESCRIPTION
Docker Compose에 개별 PostgreSQL 환경변수 추가

추가된 환경변수:
- POSTGRES_HOST=postgres
- POSTGRES_PORT=5432
- POSTGRES_USER
- POSTGRES_PASSWORD
- POSTGRES_DB

DATABASE_URL에 포함되어 있지만, 애플리케이션에서 개별적으로 접근할 수 있도록 명시적으로 추가합니다.