### PR TITLE
feat(backend): 컬렉션 도메인 확장 (Badge, Mastery, Title, Reward, CharacterCollection)

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -43,6 +43,9 @@ func main() {
 	mealRepo := repository.NewMealRepository(db)
 	dailyIntakeRepo := repository.NewDailyIntakeRepository(db)
 	charCollectionRepo := repository.NewCharacterCollectionRepository(db)
+	masteryRepo := repository.NewMasteryRepository(db)
+	titleRepo := repository.NewTitleRepository(db)
+	rewardRepo := repository.NewRewardRepository(db)
 
 	// Auth 도메인
 	authUsecase := usecase.NewAuthUsecase(userRepo)
@@ -55,7 +58,11 @@ func main() {
 	// Collection 도메인
 	badgeGranter := usecase.NewBadgeGranter(badgeRepo, mealRepo, dailyIntakeRepo, charCollectionRepo)
 	badgeUsecase := usecase.NewBadgeUsecase(badgeRepo)
-	collectionHandler := handler.NewCollectionHandler(badgeUsecase)
+	charCollectionUsecase := usecase.NewCharacterCollectionUsecase(charCollectionRepo)
+	masteryUsecase := usecase.NewMasteryUsecase(masteryRepo)
+	titleUsecase := usecase.NewTitleUsecase(titleRepo, userRepo)
+	rewardUsecase := usecase.NewRewardUsecase(rewardRepo)
+	collectionHandler := handler.NewCollectionHandler(badgeUsecase, charCollectionUsecase, masteryUsecase, titleUsecase, rewardUsecase)
 
 	// Menu 도메인
 	menuUsecase := usecase.NewMenuUsecase(menuRepo)

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -40,6 +40,9 @@ func main() {
 	userRepo := repository.NewUserRepository(db)
 	badgeRepo := repository.NewBadgeRepository(db)
 	menuRepo := repository.NewMenuRepository(db)
+	mealRepo := repository.NewMealRepository(db)
+	dailyIntakeRepo := repository.NewDailyIntakeRepository(db)
+	charCollectionRepo := repository.NewCharacterCollectionRepository(db)
 
 	// Auth 도메인
 	authUsecase := usecase.NewAuthUsecase(userRepo)
@@ -50,12 +53,15 @@ func main() {
 	userHandler := handler.NewUserHandler(userUsecase)
 
 	// Collection 도메인
+	badgeGranter := usecase.NewBadgeGranter(badgeRepo, mealRepo, dailyIntakeRepo, charCollectionRepo)
 	badgeUsecase := usecase.NewBadgeUsecase(badgeRepo)
 	collectionHandler := handler.NewCollectionHandler(badgeUsecase)
 
 	// Menu 도메인
 	menuUsecase := usecase.NewMenuUsecase(menuRepo)
 	menuHandler := handler.NewMenuHandler(menuUsecase)
+
+	_ = badgeGranter // Meal 유즈케이스 구현 시 주입
 
 	// 라우터 초기화 (모든 미들웨어 및 라우트 등록)
 	r := route.NewRouter(

--- a/backend/internal/delivery/http/dto/collection.go
+++ b/backend/internal/delivery/http/dto/collection.go
@@ -1,6 +1,10 @@
 package dto
 
-import "time"
+import (
+	"time"
+
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+)
 
 // BadgeResponse API 응답용 뱃지 정보
 type BadgeResponse struct {
@@ -11,4 +15,53 @@ type BadgeResponse struct {
 	IconURL     string     `json:"icon_url"`
 	Acquired    bool       `json:"acquired"`
 	AcquiredAt  *time.Time `json:"acquired_at,omitempty"`
+}
+
+// CharacterCollectionResponse 먹찌 도감 응답
+type CharacterCollectionResponse struct {
+	ID         int64     `json:"id,string"`
+	BodyType   int       `json:"body_type"`
+	Muscle     int       `json:"muscle"`
+	SkinTone   int       `json:"skin_tone"`
+	Expression int       `json:"expression"`
+	AchievedAt time.Time `json:"achieved_at"`
+}
+
+// MasteryResponse 마스터리 응답
+type MasteryResponse struct {
+	ID           int64               `json:"id,string"`
+	MenuID       int64               `json:"menu_id,string"`
+	MenuName     string              `json:"menu_name"`
+	MenuCategory domain.MenuCategory `json:"menu_category"`
+	EatCount     int                 `json:"eat_count"`
+	Grade        domain.MasteryGrade `json:"grade"`
+	FirstEatenAt time.Time           `json:"first_eaten_at"`
+	LastEatenAt  time.Time           `json:"last_eaten_at"`
+}
+
+// TitleResponse 칭호 응답
+type TitleResponse struct {
+	ID          int64      `json:"id,string"`
+	Code        string     `json:"code"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Acquired    bool       `json:"acquired"`
+	AchievedAt  *time.Time `json:"achieved_at,omitempty"`
+	IsEquipped  bool       `json:"is_equipped"`
+}
+
+// EquipTitleRequest 칭호 장착/해제 요청 (title_id가 null이면 해제)
+type EquipTitleRequest struct {
+	TitleID *string `json:"title_id"`
+}
+
+// RewardResponse 보상 아이템 응답
+type RewardResponse struct {
+	ID          int64             `json:"id,string"`
+	RewardType  domain.RewardType `json:"reward_type"`
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	AssetURL    string            `json:"asset_url"`
+	Acquired    bool              `json:"acquired"`
+	AchievedAt  *time.Time        `json:"achieved_at,omitempty"`
 }

--- a/backend/internal/delivery/http/handler/collection.go
+++ b/backend/internal/delivery/http/handler/collection.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -12,13 +13,27 @@ import (
 
 // CollectionHandler 컬렉션 핸들러
 type CollectionHandler struct {
-	badgeUsecase usecase.BadgeUsecase
+	badgeUsecase          usecase.BadgeUsecase
+	charCollectionUsecase usecase.CharacterCollectionUsecase
+	masteryUsecase        usecase.MasteryUsecase
+	titleUsecase          usecase.TitleUsecase
+	rewardUsecase         usecase.RewardUsecase
 }
 
 // NewCollectionHandler 컬렉션 핸들러 생성
-func NewCollectionHandler(badgeUsecase usecase.BadgeUsecase) *CollectionHandler {
+func NewCollectionHandler(
+	badgeUsecase usecase.BadgeUsecase,
+	charCollectionUsecase usecase.CharacterCollectionUsecase,
+	masteryUsecase usecase.MasteryUsecase,
+	titleUsecase usecase.TitleUsecase,
+	rewardUsecase usecase.RewardUsecase,
+) *CollectionHandler {
 	return &CollectionHandler{
-		badgeUsecase: badgeUsecase,
+		badgeUsecase:          badgeUsecase,
+		charCollectionUsecase: charCollectionUsecase,
+		masteryUsecase:        masteryUsecase,
+		titleUsecase:          titleUsecase,
+		rewardUsecase:         rewardUsecase,
 	}
 }
 
@@ -29,16 +44,15 @@ func NewCollectionHandler(badgeUsecase usecase.BadgeUsecase) *CollectionHandler 
 // @Accept       json
 // @Produce      json
 // @Security     BearerAuth
-// @Param        include_acquired  query     bool    false  "획득한 뱃지 포함 여부 (기본값: true, 허용값: 'true'|'false')"
+// @Param        include_acquired  query     bool    false  "획득한 뱃지 포함 여부 (기본값: true)"
 // @Param        limit             query     int     false  "페이지당 항목 수 (기본값: 20, 범위: 1-50)"
-// @Param        cursor            query     string  false  "다음 페이지 커서 (이전 응답의 next_cursor 값 사용)"
+// @Param        cursor            query     string  false  "다음 페이지 커서"
 // @Success      200  {object}  Response  "뱃지 목록 조회 성공"
 // @Failure      400  {object}  Response  "잘못된 쿼리 파라미터"
 // @Failure      401  {object}  Response  "인증 토큰 누락 또는 유효하지 않음"
 // @Failure      500  {object}  Response  "서버 내부 에러"
 // @Router       /api/collections/badges [get]
 func (h *CollectionHandler) GetBadges(c *gin.Context) {
-	// 인증 확인 (미들웨어에서 설정한 userID 사용)
 	userIDVal, exists := c.Get("userID")
 	if !exists {
 		Unauthorized(c, "UNAUTHORIZED", "인증 토큰이 누락되었거나 유효하지 않습니다.", "BearerToken을 포함한 Authorization 헤더를 확인하세요.")
@@ -46,34 +60,30 @@ func (h *CollectionHandler) GetBadges(c *gin.Context) {
 	}
 	userID := userIDVal.(int64)
 
-	// 쿼리 파라미터 파싱
 	includeAcquiredStr := c.Query("include_acquired")
 	limitStr := c.Query("limit")
 	cursor := c.Query("cursor")
 
-	// include_acquired 파싱 (기본값: true)
 	includeAcquired := true
 	if includeAcquiredStr != "" {
 		if includeAcquiredStr == "false" {
 			includeAcquired = false
 		} else if includeAcquiredStr != "true" {
-			BadRequest(c, "INVALID_PARAMETER", "include_acquired 파라미터는 'true' 또는 'false'여야 합니다.", map[string]any{"parameter": "include_acquired", "allowed": []string{"true", "false"}})
+			BadRequest(c, "INVALID_PARAMETER", "include_acquired 파라미터는 'true' 또는 'false'여야 합니다.", map[string]any{"parameter": "include_acquired"})
 			return
 		}
 	}
 
-	// limit 파싱 (기본값: 20, 최대값: 50)
 	limit := 20
 	if limitStr != "" {
 		parsedLimit, err := strconv.Atoi(limitStr)
 		if err != nil || parsedLimit <= 0 || parsedLimit > 50 {
-			BadRequest(c, "INVALID_PARAMETER", "limit 파라미터는 1 이상 50 이하의 정수여야 합니다.", map[string]any{"parameter": "limit", "min": 1, "max": 50, "default": 20})
+			BadRequest(c, "INVALID_PARAMETER", "limit 파라미터는 1 이상 50 이하의 정수여야 합니다.", map[string]any{"parameter": "limit", "min": 1, "max": 50})
 			return
 		}
 		limit = parsedLimit
 	}
 
-	// 유즈케이스 호출
 	result, err := h.badgeUsecase.GetBadges(c.Request.Context(), domain.GetBadgesQuery{
 		UserID:          userID,
 		IncludeAcquired: includeAcquired,
@@ -81,19 +91,15 @@ func (h *CollectionHandler) GetBadges(c *gin.Context) {
 		Limit:           limit,
 	})
 	if err != nil {
-		// BadgeError 타입 확인
 		badgeErr, ok := err.(*usecase.BadgeError)
 		if !ok {
 			InternalError(c, "서버 내부 오류가 발생했습니다.")
 			return
 		}
-
-		// BadgeError 코드별 처리
 		Error(c, http.StatusInternalServerError, badgeErr.Code, badgeErr.Message, badgeErr.Details)
 		return
 	}
 
-	// 성공 응답 (CursorPaginated 사용)
 	responses := make([]dto.BadgeResponse, len(result.Badges))
 	for i, badge := range result.Badges {
 		userBadge, isAcquired := result.AcquiredMap[badge.ID]
@@ -111,4 +117,269 @@ func (h *CollectionHandler) GetBadges(c *gin.Context) {
 	}
 
 	CursorPaginated(c, responses, result.Limit, result.HasNext, result.NextCursor)
+}
+
+// GetCharacterCollections 먹찌 도감 조회
+// @Summary      먹찌 도감 조회
+// @Description  사용자가 달성한 먹찌 외형 컬렉션 목록을 반환합니다.
+// @Tags         collections
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        page   query  int  false  "페이지 번호 (기본값: 1)"
+// @Param        limit  query  int  false  "페이지당 항목 수 (기본값: 20, 최대: 100)"
+// @Success      200  {object}  Response  "먹찌 도감 조회 성공"
+// @Failure      401  {object}  Response  "인증 토큰 누락 또는 유효하지 않음"
+// @Failure      500  {object}  Response  "서버 내부 에러"
+// @Router       /api/collections/characters [get]
+func (h *CollectionHandler) GetCharacterCollections(c *gin.Context) {
+	userID := c.MustGet("userID").(int64)
+
+	page, limit := parsePagination(c)
+
+	collections, total, err := h.charCollectionUsecase.GetCharacterCollections(userID, page, limit)
+	if err != nil {
+		InternalError(c, "먹찌 도감을 조회하는 중에 오류가 발생했습니다.")
+		return
+	}
+
+	responses := make([]dto.CharacterCollectionResponse, len(collections))
+	for i, col := range collections {
+		responses[i] = dto.CharacterCollectionResponse{
+			ID:         col.ID,
+			BodyType:   col.BodyType,
+			Muscle:     col.Muscle,
+			SkinTone:   col.SkinTone,
+			Expression: col.Expression,
+			AchievedAt: col.AchievedAt,
+		}
+	}
+
+	Paginated(c, responses, total, page, limit)
+}
+
+// GetMasteries 마스터리 목록 조회
+// @Summary      마스터리 목록 조회
+// @Description  사용자의 메뉴 마스터리 목록을 반환합니다.
+// @Tags         collections
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        page   query  int  false  "페이지 번호 (기본값: 1)"
+// @Param        limit  query  int  false  "페이지당 항목 수 (기본값: 20, 최대: 50)"
+// @Success      200  {object}  Response  "마스터리 목록 조회 성공"
+// @Failure      401  {object}  Response  "인증 토큰 누락 또는 유효하지 않음"
+// @Failure      500  {object}  Response  "서버 내부 에러"
+// @Router       /api/collections/mastery [get]
+func (h *CollectionHandler) GetMasteries(c *gin.Context) {
+	userID := c.MustGet("userID").(int64)
+
+	page, limit := parsePagination(c)
+
+	masteries, total, err := h.masteryUsecase.GetMasteries(userID, page, limit)
+	if err != nil {
+		InternalError(c, "마스터리 목록을 조회하는 중에 오류가 발생했습니다.")
+		return
+	}
+
+	responses := make([]dto.MasteryResponse, len(masteries))
+	for i, m := range masteries {
+		responses[i] = dto.MasteryResponse{
+			ID:           m.ID,
+			MenuID:       m.MenuID,
+			MenuName:     m.Menu.Name,
+			MenuCategory: m.Menu.Category,
+			EatCount:     m.EatCount,
+			Grade:        m.Grade,
+			FirstEatenAt: m.FirstEatenAt,
+			LastEatenAt:  m.LastEatenAt,
+		}
+	}
+
+	Paginated(c, responses, total, page, limit)
+}
+
+// GetMasteryByMenu 특정 메뉴 마스터리 상세 조회
+// @Summary      특정 메뉴 마스터리 상세 조회
+// @Description  특정 메뉴에 대한 사용자의 마스터리 상세 정보를 반환합니다.
+// @Tags         collections
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        menuId  path  string  true  "메뉴 ID"
+// @Success      200  {object}  Response  "마스터리 상세 조회 성공"
+// @Failure      400  {object}  Response  "잘못된 메뉴 ID"
+// @Failure      401  {object}  Response  "인증 토큰 누락 또는 유효하지 않음"
+// @Failure      404  {object}  Response  "마스터리 없음"
+// @Failure      500  {object}  Response  "서버 내부 에러"
+// @Router       /api/collections/mastery/{menuId} [get]
+func (h *CollectionHandler) GetMasteryByMenu(c *gin.Context) {
+	userID := c.MustGet("userID").(int64)
+
+	menuIDStr := c.Param("menuId")
+	menuID, err := strconv.ParseInt(menuIDStr, 10, 64)
+	if err != nil {
+		BadRequest(c, "INVALID_PARAMETER", "올바른 메뉴 ID를 입력해주세요.")
+		return
+	}
+
+	mastery, err := h.masteryUsecase.GetMasteryByMenu(userID, menuID)
+	if err != nil {
+		InternalError(c, "마스터리 정보를 조회하는 중에 오류가 발생했습니다.")
+		return
+	}
+	if mastery == nil {
+		NotFound(c, "MASTERY_NOT_FOUND", "해당 메뉴의 마스터리 기록이 없습니다.")
+		return
+	}
+
+	Success(c, dto.MasteryResponse{
+		ID:           mastery.ID,
+		MenuID:       mastery.MenuID,
+		MenuName:     mastery.Menu.Name,
+		MenuCategory: mastery.Menu.Category,
+		EatCount:     mastery.EatCount,
+		Grade:        mastery.Grade,
+		FirstEatenAt: mastery.FirstEatenAt,
+		LastEatenAt:  mastery.LastEatenAt,
+	})
+}
+
+// GetTitles 칭호 목록 조회
+// @Summary      칭호 목록 조회
+// @Description  전체 칭호 목록과 획득/장착 여부를 반환합니다.
+// @Tags         collections
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200  {object}  Response  "칭호 목록 조회 성공"
+// @Failure      401  {object}  Response  "인증 토큰 누락 또는 유효하지 않음"
+// @Failure      500  {object}  Response  "서버 내부 에러"
+// @Router       /api/collections/titles [get]
+func (h *CollectionHandler) GetTitles(c *gin.Context) {
+	userID := c.MustGet("userID").(int64)
+
+	titles, acquiredMap, equippedTitleID, err := h.titleUsecase.GetTitles(userID)
+	if err != nil {
+		InternalError(c, "칭호 목록을 조회하는 중에 오류가 발생했습니다.")
+		return
+	}
+
+	responses := make([]dto.TitleResponse, len(titles))
+	for i, title := range titles {
+		ut, acquired := acquiredMap[title.ID]
+		resp := dto.TitleResponse{
+			ID:          title.ID,
+			Code:        title.Code,
+			Name:        title.Name,
+			Description: title.Description,
+			Acquired:    acquired,
+			IsEquipped:  equippedTitleID != nil && *equippedTitleID == title.ID,
+		}
+		if acquired && ut != nil {
+			resp.AchievedAt = &ut.AchievedAt
+		}
+		responses[i] = resp
+	}
+
+	Success(c, responses)
+}
+
+// EquipTitle 칭호 장착/해제
+// @Summary      칭호 장착/해제
+// @Description  보유한 칭호를 장착하거나 해제합니다. title_id를 null로 전송하면 해제됩니다.
+// @Tags         collections
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        EquipTitleRequest  body  dto.EquipTitleRequest  true  "칭호 장착 요청"
+// @Success      200  {object}  Response  "칭호 장착/해제 성공"
+// @Failure      400  {object}  Response  "잘못된 요청 형식 또는 보유하지 않은 칭호"
+// @Failure      401  {object}  Response  "인증 토큰 누락 또는 유효하지 않음"
+// @Failure      500  {object}  Response  "서버 내부 에러"
+// @Router       /api/collections/titles/equip [patch]
+func (h *CollectionHandler) EquipTitle(c *gin.Context) {
+	userID := c.MustGet("userID").(int64)
+
+	var req dto.EquipTitleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		BadRequest(c, "INVALID_REQUEST", "잘못된 요청 형식입니다.")
+		return
+	}
+
+	// title_id string -> *int64 변환
+	var titleID *int64
+	if req.TitleID != nil {
+		id, err := strconv.ParseInt(*req.TitleID, 10, 64)
+		if err != nil {
+			BadRequest(c, "INVALID_PARAMETER", "올바른 칭호 ID를 입력해주세요.")
+			return
+		}
+		titleID = &id
+	}
+
+	if err := h.titleUsecase.EquipTitle(userID, titleID); err != nil {
+		if errors.Is(err, usecase.ErrTitleNotOwned) {
+			BadRequest(c, "TITLE_NOT_OWNED", err.Error())
+			return
+		}
+		InternalError(c, "칭호 장착에 실패했습니다.")
+		return
+	}
+
+	Success(c, gin.H{"message": "칭호가 변경되었습니다."})
+}
+
+// GetRewards 보상 아이템 목록 조회
+// @Summary      보상 아이템 목록 조회
+// @Description  전체 보상 아이템 목록과 획득 여부를 반환합니다.
+// @Tags         collections
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200  {object}  Response  "보상 목록 조회 성공"
+// @Failure      401  {object}  Response  "인증 토큰 누락 또는 유효하지 않음"
+// @Failure      500  {object}  Response  "서버 내부 에러"
+// @Router       /api/collections/rewards [get]
+func (h *CollectionHandler) GetRewards(c *gin.Context) {
+	userID := c.MustGet("userID").(int64)
+
+	rewards, acquiredMap, err := h.rewardUsecase.GetRewards(userID)
+	if err != nil {
+		InternalError(c, "보상 목록을 조회하는 중에 오류가 발생했습니다.")
+		return
+	}
+
+	responses := make([]dto.RewardResponse, len(rewards))
+	for i, reward := range rewards {
+		ur, acquired := acquiredMap[reward.ID]
+		resp := dto.RewardResponse{
+			ID:          reward.ID,
+			RewardType:  reward.RewardType,
+			Name:        reward.Name,
+			Description: reward.Description,
+			AssetURL:    reward.AssetURL,
+			Acquired:    acquired,
+		}
+		if acquired && ur != nil {
+			resp.AchievedAt = &ur.AchievedAt
+		}
+		responses[i] = resp
+	}
+
+	Success(c, responses)
+}
+
+// parsePagination 쿼리 파라미터에서 page, limit 파싱
+func parsePagination(c *gin.Context) (page, limit int) {
+	page = 1
+	limit = 20
+
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 && l <= 100 {
+		limit = l
+	}
+	return
 }

--- a/backend/internal/delivery/http/route/collection.go
+++ b/backend/internal/delivery/http/route/collection.go
@@ -10,9 +10,14 @@ import (
 func CollectionRoute(rg *gin.RouterGroup, collectionHandler *handler.CollectionHandler) {
 	collections := rg.Group("/collections")
 	{
-		// 로그인이 필요한 요청들에 미들웨어 적용
 		collections.Use(middleware.AuthMiddleware())
 
+		collections.GET("/characters", collectionHandler.GetCharacterCollections)
+		collections.GET("/mastery", collectionHandler.GetMasteries)
+		collections.GET("/mastery/:menuId", collectionHandler.GetMasteryByMenu)
 		collections.GET("/badges", collectionHandler.GetBadges)
+		collections.GET("/titles", collectionHandler.GetTitles)
+		collections.PATCH("/titles/equip", collectionHandler.EquipTitle)
+		collections.GET("/rewards", collectionHandler.GetRewards)
 	}
 }

--- a/backend/internal/domain/character.go
+++ b/backend/internal/domain/character.go
@@ -1,0 +1,17 @@
+package domain
+
+import "time"
+
+type CharacterCollection struct {
+	BaseDomain
+	UserID     int64     `gorm:"not null;uniqueIndex:idx_char_collection"`
+	BodyType   int       `gorm:"not null;uniqueIndex:idx_char_collection"`
+	Muscle     int       `gorm:"not null;uniqueIndex:idx_char_collection"`
+	SkinTone   int       `gorm:"not null;uniqueIndex:idx_char_collection"`
+	Expression int       `gorm:"not null;uniqueIndex:idx_char_collection"`
+	AchievedAt time.Time `gorm:"not null"`
+}
+
+func (CharacterCollection) TableName() string {
+	return "character_collections"
+}

--- a/backend/internal/domain/collection.go
+++ b/backend/internal/domain/collection.go
@@ -2,6 +2,106 @@ package domain
 
 import "time"
 
+// --- Mastery ---
+
+// MasteryGrade 마스터리 등급
+type MasteryGrade string
+
+const (
+	MasteryBeginner MasteryGrade = "BEGINNER"
+	MasteryMania    MasteryGrade = "MANIA"
+	MasteryArtisan  MasteryGrade = "ARTISAN"
+	MasteryMaster   MasteryGrade = "MASTER"
+)
+
+// CalcMasteryGrade 섭취 횟수로부터 마스터리 등급 계산
+func CalcMasteryGrade(eatCount int) MasteryGrade {
+	switch {
+	case eatCount >= 50:
+		return MasteryMaster
+	case eatCount >= 20:
+		return MasteryArtisan
+	case eatCount >= 5:
+		return MasteryMania
+	default:
+		return MasteryBeginner
+	}
+}
+
+// Mastery 메뉴 마스터리
+type Mastery struct {
+	BaseDomain
+	UserID       int64        `gorm:"not null;uniqueIndex:idx_mastery_user_menu"`
+	MenuID       int64        `gorm:"not null;uniqueIndex:idx_mastery_user_menu"`
+	EatCount     int          `gorm:"default:0"`
+	Grade        MasteryGrade `gorm:"type:varchar(20);default:'BEGINNER'"`
+	FirstEatenAt time.Time    `gorm:"not null"`
+	LastEatenAt  time.Time    `gorm:"not null"`
+	Menu         Menu         `gorm:"foreignKey:MenuID"`
+}
+
+func (Mastery) TableName() string { return "masteries" }
+
+// --- Title ---
+
+// Title 칭호 정의
+type Title struct {
+	BaseDomain
+	Code        string `gorm:"uniqueIndex;not null;type:varchar(50)"`
+	Name        string `gorm:"not null;type:varchar(50)"`
+	Description string `gorm:"type:text"`
+}
+
+func (Title) TableName() string { return "titles" }
+
+// UserTitle 사용자 칭호 획득 기록
+type UserTitle struct {
+	BaseDomain
+	UserID     int64     `gorm:"not null;uniqueIndex:idx_user_title"`
+	TitleID    int64     `gorm:"not null;uniqueIndex:idx_user_title"`
+	AchievedAt time.Time `gorm:"not null"`
+	Title      Title     `gorm:"foreignKey:TitleID"`
+}
+
+func (UserTitle) TableName() string { return "user_titles" }
+
+// --- Reward ---
+
+// RewardType 보상 유형
+type RewardType string
+
+const (
+	RewardBackground RewardType = "BACKGROUND"
+	RewardEffect     RewardType = "EFFECT"
+	RewardMotion     RewardType = "MOTION"
+	RewardAccessory  RewardType = "ACCESSORY"
+)
+
+// Reward 보상 아이템
+type Reward struct {
+	BaseDomain
+	RewardType  RewardType `gorm:"type:varchar(20);not null"`
+	Name        string     `gorm:"not null;type:varchar(50)"`
+	Description string     `gorm:"type:text"`
+	AssetURL    string     `gorm:"type:text"`
+}
+
+func (Reward) TableName() string { return "rewards" }
+
+// UserReward 사용자 보상 획득 기록
+type UserReward struct {
+	BaseDomain
+	UserID     int64     `gorm:"not null;uniqueIndex:idx_user_reward"`
+	RewardID   int64     `gorm:"not null;uniqueIndex:idx_user_reward"`
+	QuestID    *int64    `gorm:"type:bigint"`
+	AchievedAt time.Time `gorm:"not null"`
+	Reward     Reward    `gorm:"foreignKey:RewardID"`
+}
+
+func (UserReward) TableName() string { return "user_rewards" }
+
+// --- Badge ---
+
 // Badge 뱃지 정의
 type Badge struct {
 	BaseDomain

--- a/backend/internal/domain/meal.go
+++ b/backend/internal/domain/meal.go
@@ -1,0 +1,52 @@
+package domain
+
+import "time"
+
+type MealType string
+
+const (
+	MealTypeBreakfast MealType = "BREAKFAST"
+	MealTypeLunch     MealType = "LUNCH"
+	MealTypeDinner    MealType = "DINNER"
+	MealTypeSnack     MealType = "SNACK"
+)
+
+type MealRecord struct {
+	BaseDomain
+	UserID      int64        `gorm:"not null;index:idx_meal_records_user_recorded"`
+	MenuID      *int64       `gorm:"index"`
+	ImageURL    string       `gorm:"type:text"`
+	MenuName    string       `gorm:"type:varchar(100);not null"`
+	Category    MenuCategory `gorm:"type:varchar(20);not null"`
+	MealType    MealType     `gorm:"type:varchar(20);not null"`
+	ServingSize float64      `gorm:"default:1.0"`
+	RecordedAt  time.Time    `gorm:"not null;index:idx_meal_records_user_recorded"`
+	WeatherTag  string       `gorm:"type:varchar(20)"`
+	MoodTag     string       `gorm:"type:varchar(20)"`
+	Review      string       `gorm:"type:text"`
+	Rating      *int         `gorm:"check:rating BETWEEN 1 AND 5"`
+	IsManual    bool         `gorm:"default:false"`
+}
+
+func (MealRecord) TableName() string {
+	return "meal_records"
+}
+
+type DailyIntake struct {
+	BaseDomain
+	UserID        int64     `gorm:"not null;uniqueIndex:idx_daily_intakes_user_date"`
+	Date          time.Time `gorm:"type:date;not null;uniqueIndex:idx_daily_intakes_user_date"`
+	TotalCalories float64   `gorm:"default:0"`
+	TotalCarbs    float64   `gorm:"default:0"`
+	TotalProtein  float64   `gorm:"default:0"`
+	TotalFat      float64   `gorm:"default:0"`
+	TotalSodium   float64   `gorm:"default:0"`
+	TotalFiber    float64   `gorm:"default:0"`
+	VitaminScore  float64   `gorm:"default:0"`
+	MealCount     int       `gorm:"default:0"`
+	IsBalanced    bool      `gorm:"default:false"`
+}
+
+func (DailyIntake) TableName() string {
+	return "daily_intakes"
+}

--- a/backend/internal/repository/badge.go
+++ b/backend/internal/repository/badge.go
@@ -24,6 +24,9 @@ type BadgeRepository interface {
 
 	// FindUserBadgeByID 사용자 뱃지 기록 조회
 	FindUserBadgeByID(userID, badgeID int64) (*domain.UserBadge, error)
+
+	// FindBadgeByCode 뱃지 코드로 조회
+	FindBadgeByCode(code string) (*domain.Badge, error)
 }
 
 // badgeRepositoryImpl 뱃지 저장소 구현체
@@ -86,6 +89,18 @@ func (r *badgeRepositoryImpl) FindBadgeByID(badgeID int64) (*domain.Badge, error
 // CreateUserBadge 사용자 뱃지 기록 생성
 func (r *badgeRepositoryImpl) CreateUserBadge(userBadge *domain.UserBadge) error {
 	return r.db.Create(userBadge).Error
+}
+
+// FindBadgeByCode 뱃지 코드로 조회
+func (r *badgeRepositoryImpl) FindBadgeByCode(code string) (*domain.Badge, error) {
+	var badge domain.Badge
+	if err := r.db.Where("code = ?", code).First(&badge).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &badge, nil
 }
 
 // FindUserBadgeByID 사용자 뱃지 기록 조회

--- a/backend/internal/repository/character_collection.go
+++ b/backend/internal/repository/character_collection.go
@@ -9,6 +9,9 @@ import (
 type CharacterCollectionRepository interface {
 	// CountByUserID 사용자가 달성한 외형 종류 수
 	CountByUserID(userID int64) (int64, error)
+
+	// FindByUserID 사용자가 달성한 외형 목록 조회
+	FindByUserID(userID int64, limit, offset int) ([]domain.CharacterCollection, int64, error)
 }
 
 type characterCollectionRepositoryImpl struct {
@@ -27,4 +30,25 @@ func (r *characterCollectionRepositoryImpl) CountByUserID(userID int64) (int64, 
 		return 0, err
 	}
 	return count, nil
+}
+
+func (r *characterCollectionRepositoryImpl) FindByUserID(userID int64, limit, offset int) ([]domain.CharacterCollection, int64, error) {
+	var collections []domain.CharacterCollection
+	var total int64
+
+	if err := r.db.Model(&domain.CharacterCollection{}).
+		Where("user_id = ?", userID).
+		Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	if err := r.db.Where("user_id = ?", userID).
+		Order("achieved_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&collections).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return collections, total, nil
 }

--- a/backend/internal/repository/character_collection.go
+++ b/backend/internal/repository/character_collection.go
@@ -1,0 +1,30 @@
+package repository
+
+import (
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// CharacterCollectionRepository 먹찌 도감 저장소 인터페이스
+type CharacterCollectionRepository interface {
+	// CountByUserID 사용자가 달성한 외형 종류 수
+	CountByUserID(userID int64) (int64, error)
+}
+
+type characterCollectionRepositoryImpl struct {
+	db *gorm.DB
+}
+
+func NewCharacterCollectionRepository(db *gorm.DB) CharacterCollectionRepository {
+	return &characterCollectionRepositoryImpl{db: db}
+}
+
+func (r *characterCollectionRepositoryImpl) CountByUserID(userID int64) (int64, error) {
+	var count int64
+	if err := r.db.Model(&domain.CharacterCollection{}).
+		Where("user_id = ?", userID).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/backend/internal/repository/daily_intake.go
+++ b/backend/internal/repository/daily_intake.go
@@ -1,0 +1,50 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// DailyIntakeRepository 일일 섭취 통계 저장소 인터페이스
+type DailyIntakeRepository interface {
+	// FindByUserIDAndDate 특정 날짜의 일일 섭취 통계 조회
+	FindByUserIDAndDate(userID int64, date time.Time) (*domain.DailyIntake, error)
+
+	// FindRecentByUserID 최근 N일 일일 섭취 통계 조회 (날짜 내림차순)
+	FindRecentByUserID(userID int64, limit int) ([]domain.DailyIntake, error)
+}
+
+type dailyIntakeRepositoryImpl struct {
+	db *gorm.DB
+}
+
+func NewDailyIntakeRepository(db *gorm.DB) DailyIntakeRepository {
+	return &dailyIntakeRepositoryImpl{db: db}
+}
+
+func (r *dailyIntakeRepositoryImpl) FindByUserIDAndDate(userID int64, date time.Time) (*domain.DailyIntake, error) {
+	var intake domain.DailyIntake
+	if err := r.db.
+		Where("user_id = ? AND date = ?", userID, date).
+		First(&intake).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &intake, nil
+}
+
+func (r *dailyIntakeRepositoryImpl) FindRecentByUserID(userID int64, limit int) ([]domain.DailyIntake, error) {
+	var intakes []domain.DailyIntake
+	if err := r.db.
+		Where("user_id = ?", userID).
+		Order("date DESC").
+		Limit(limit).
+		Find(&intakes).Error; err != nil {
+		return nil, err
+	}
+	return intakes, nil
+}

--- a/backend/internal/repository/mastery.go
+++ b/backend/internal/repository/mastery.go
@@ -1,0 +1,103 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// MasteryRepository 마스터리 저장소 인터페이스
+type MasteryRepository interface {
+	// FindByUserID 사용자의 마스터리 목록 조회
+	FindByUserID(userID int64, limit, offset int) ([]domain.Mastery, int64, error)
+
+	// FindByUserIDAndMenuID 특정 메뉴의 마스터리 조회
+	FindByUserIDAndMenuID(userID, menuID int64) (*domain.Mastery, error)
+
+	// Upsert 마스터리 생성 또는 eat_count/grade 갱신
+	Upsert(userID, menuID int64, now time.Time) (*domain.Mastery, error)
+}
+
+type masteryRepositoryImpl struct {
+	db *gorm.DB
+}
+
+func NewMasteryRepository(db *gorm.DB) MasteryRepository {
+	return &masteryRepositoryImpl{db: db}
+}
+
+func (r *masteryRepositoryImpl) FindByUserID(userID int64, limit, offset int) ([]domain.Mastery, int64, error) {
+	var masteries []domain.Mastery
+	var total int64
+
+	if err := r.db.Model(&domain.Mastery{}).
+		Where("user_id = ?", userID).
+		Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	if err := r.db.Preload("Menu").
+		Where("user_id = ?", userID).
+		Order("eat_count DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&masteries).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return masteries, total, nil
+}
+
+func (r *masteryRepositoryImpl) FindByUserIDAndMenuID(userID, menuID int64) (*domain.Mastery, error) {
+	var mastery domain.Mastery
+	if err := r.db.Preload("Menu").
+		Where("user_id = ? AND menu_id = ?", userID, menuID).
+		First(&mastery).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &mastery, nil
+}
+
+// Upsert eat_count를 1 증가시키고 grade를 갱신합니다. SELECT FOR UPDATE로 동시성을 제어합니다.
+func (r *masteryRepositoryImpl) Upsert(userID, menuID int64, now time.Time) (*domain.Mastery, error) {
+	var mastery domain.Mastery
+
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		// 비관적 잠금으로 기존 레코드 조회
+		result := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("user_id = ? AND menu_id = ?", userID, menuID).
+			First(&mastery)
+
+		if result.Error == gorm.ErrRecordNotFound {
+			// 신규 생성
+			mastery = domain.Mastery{
+				UserID:       userID,
+				MenuID:       menuID,
+				EatCount:     1,
+				Grade:        domain.CalcMasteryGrade(1),
+				FirstEatenAt: now,
+				LastEatenAt:  now,
+			}
+			return tx.Create(&mastery).Error
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+
+		// 기존 레코드 갱신
+		mastery.EatCount++
+		mastery.Grade = domain.CalcMasteryGrade(mastery.EatCount)
+		mastery.LastEatenAt = now
+		return tx.Save(&mastery).Error
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return &mastery, nil
+}

--- a/backend/internal/repository/meal.go
+++ b/backend/internal/repository/meal.go
@@ -1,0 +1,44 @@
+package repository
+
+import (
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// MealRepository 식사 기록 저장소 인터페이스
+type MealRepository interface {
+	// CountByUserID 사용자의 전체 식사 기록 수
+	CountByUserID(userID int64) (int64, error)
+
+	// CountDistinctMenuByUserID 사용자가 기록한 서로 다른 메뉴 수
+	CountDistinctMenuByUserID(userID int64) (int64, error)
+}
+
+type mealRepositoryImpl struct {
+	db *gorm.DB
+}
+
+func NewMealRepository(db *gorm.DB) MealRepository {
+	return &mealRepositoryImpl{db: db}
+}
+
+func (r *mealRepositoryImpl) CountByUserID(userID int64) (int64, error) {
+	var count int64
+	if err := r.db.Model(&domain.MealRecord{}).
+		Where("user_id = ?", userID).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (r *mealRepositoryImpl) CountDistinctMenuByUserID(userID int64) (int64, error) {
+	var count int64
+	if err := r.db.Model(&domain.MealRecord{}).
+		Where("user_id = ?", userID).
+		Distinct("menu_name").
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/backend/internal/repository/reward.go
+++ b/backend/internal/repository/reward.go
@@ -1,0 +1,49 @@
+package repository
+
+import (
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// RewardRepository 보상 저장소 인터페이스
+type RewardRepository interface {
+	// FindAll 전체 보상 아이템 목록 조회
+	FindAll() ([]domain.Reward, error)
+
+	// FindUserRewards 사용자가 획득한 보상 목록 조회
+	FindUserRewards(userID int64) ([]domain.UserReward, error)
+
+	// CreateUserReward 보상 지급
+	CreateUserReward(userReward *domain.UserReward) error
+}
+
+type rewardRepositoryImpl struct {
+	db *gorm.DB
+}
+
+func NewRewardRepository(db *gorm.DB) RewardRepository {
+	return &rewardRepositoryImpl{db: db}
+}
+
+func (r *rewardRepositoryImpl) FindAll() ([]domain.Reward, error) {
+	var rewards []domain.Reward
+	if err := r.db.Order("reward_type ASC, created_at ASC").Find(&rewards).Error; err != nil {
+		return nil, err
+	}
+	return rewards, nil
+}
+
+func (r *rewardRepositoryImpl) FindUserRewards(userID int64) ([]domain.UserReward, error) {
+	var userRewards []domain.UserReward
+	if err := r.db.Preload("Reward").
+		Where("user_id = ?", userID).
+		Order("achieved_at DESC").
+		Find(&userRewards).Error; err != nil {
+		return nil, err
+	}
+	return userRewards, nil
+}
+
+func (r *rewardRepositoryImpl) CreateUserReward(userReward *domain.UserReward) error {
+	return r.db.Create(userReward).Error
+}

--- a/backend/internal/repository/title.go
+++ b/backend/internal/repository/title.go
@@ -1,0 +1,78 @@
+package repository
+
+import (
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// TitleRepository 칭호 저장소 인터페이스
+type TitleRepository interface {
+	// FindAll 전체 칭호 목록 조회
+	FindAll() ([]domain.Title, error)
+
+	// FindByID 칭호 ID로 조회
+	FindByID(titleID int64) (*domain.Title, error)
+
+	// FindUserTitles 사용자가 획득한 칭호 목록 조회
+	FindUserTitles(userID int64) ([]domain.UserTitle, error)
+
+	// FindUserTitleByID 특정 칭호 획득 여부 조회
+	FindUserTitleByID(userID, titleID int64) (*domain.UserTitle, error)
+
+	// CreateUserTitle 칭호 지급
+	CreateUserTitle(userTitle *domain.UserTitle) error
+}
+
+type titleRepositoryImpl struct {
+	db *gorm.DB
+}
+
+func NewTitleRepository(db *gorm.DB) TitleRepository {
+	return &titleRepositoryImpl{db: db}
+}
+
+func (r *titleRepositoryImpl) FindAll() ([]domain.Title, error) {
+	var titles []domain.Title
+	if err := r.db.Order("created_at ASC").Find(&titles).Error; err != nil {
+		return nil, err
+	}
+	return titles, nil
+}
+
+func (r *titleRepositoryImpl) FindByID(titleID int64) (*domain.Title, error) {
+	var title domain.Title
+	if err := r.db.First(&title, titleID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &title, nil
+}
+
+func (r *titleRepositoryImpl) FindUserTitles(userID int64) ([]domain.UserTitle, error) {
+	var userTitles []domain.UserTitle
+	if err := r.db.Preload("Title").
+		Where("user_id = ?", userID).
+		Order("achieved_at DESC").
+		Find(&userTitles).Error; err != nil {
+		return nil, err
+	}
+	return userTitles, nil
+}
+
+func (r *titleRepositoryImpl) FindUserTitleByID(userID, titleID int64) (*domain.UserTitle, error) {
+	var userTitle domain.UserTitle
+	if err := r.db.Where("user_id = ? AND title_id = ?", userID, titleID).
+		First(&userTitle).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &userTitle, nil
+}
+
+func (r *titleRepositoryImpl) CreateUserTitle(userTitle *domain.UserTitle) error {
+	return r.db.Create(userTitle).Error
+}

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -20,6 +20,9 @@ type UserRepository interface {
 	// UserNutritionGoal
 	CreateOrUpdateNutritionGoal(goal *domain.UserNutritionGoal) error
 	GetNutritionGoal(userID int64) (*domain.UserNutritionGoal, error)
+
+	// UpdateEquippedTitle 장착 칭호 갱신 (nil이면 해제)
+	UpdateEquippedTitle(userID int64, titleID *int64) error
 }
 
 type userRepository struct {
@@ -94,6 +97,13 @@ func (r *userRepository) CreateOrUpdateNutritionGoal(goal *domain.UserNutritionG
 	}
 	goal.ID = existing.ID
 	return r.db.Save(goal).Error
+}
+
+// UpdateEquippedTitle 은 사용자의 장착 칭호를 갱신합니다.
+func (r *userRepository) UpdateEquippedTitle(userID int64, titleID *int64) error {
+	return r.db.Model(&domain.User{}).
+		Where("id = ?", userID).
+		Update("equipped_title_id", titleID).Error
 }
 
 // GetNutritionGoal 은 사용자의 영양 목표를 조회합니다.

--- a/backend/internal/usecase/auth_test.go
+++ b/backend/internal/usecase/auth_test.go
@@ -71,6 +71,11 @@ func (m *MockUserRepository) GetNutritionGoal(userID int64) (*domain.UserNutriti
 	return args.Get(0).(*domain.UserNutritionGoal), args.Error(1)
 }
 
+func (m *MockUserRepository) UpdateEquippedTitle(userID int64, titleID *int64) error {
+	args := m.Called(userID, titleID)
+	return args.Error(0)
+}
+
 func TestAuthUsecase_Register(t *testing.T) {
 	mockRepo := new(MockUserRepository)
 	uc := NewAuthUsecase(mockRepo)

--- a/backend/internal/usecase/badge_granter.go
+++ b/backend/internal/usecase/badge_granter.go
@@ -1,0 +1,263 @@
+package usecase
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/repository"
+)
+
+// BadgeGrantEvent 뱃지 체크를 트리거하는 이벤트
+type BadgeGrantEvent string
+
+const (
+	// EventMealCreated 식사 기록 생성 시 트리거
+	EventMealCreated BadgeGrantEvent = "MEAL_CREATED"
+
+	// EventAppearanceRecalculated 캐릭터 외형 재계산(Cron 05:10) 시 트리거
+	EventAppearanceRecalculated BadgeGrantEvent = "APPEARANCE_RECALCULATED"
+)
+
+// 먹찌 외형 전체 조합 수: 체형(5) x 근육(5) x 피부색(5) x 표정(5)
+const totalAppearanceCombinations = 625
+
+// BadgeGranter 뱃지 자동 부여 인터페이스
+type BadgeGranter interface {
+	// CheckAndGrant 이벤트에 해당하는 뱃지 조건을 확인하고 미획득 뱃지를 부여합니다.
+	// 새로 부여된 뱃지 목록을 반환합니다.
+	CheckAndGrant(ctx context.Context, userID int64, event BadgeGrantEvent) ([]domain.Badge, error)
+}
+
+type badgeGranterImpl struct {
+	badgeRepo      repository.BadgeRepository
+	mealRepo       repository.MealRepository
+	dailyRepo      repository.DailyIntakeRepository
+	collectionRepo repository.CharacterCollectionRepository
+}
+
+func NewBadgeGranter(
+	badgeRepo repository.BadgeRepository,
+	mealRepo repository.MealRepository,
+	dailyRepo repository.DailyIntakeRepository,
+	collectionRepo repository.CharacterCollectionRepository,
+) BadgeGranter {
+	return &badgeGranterImpl{
+		badgeRepo:      badgeRepo,
+		mealRepo:       mealRepo,
+		dailyRepo:      dailyRepo,
+		collectionRepo: collectionRepo,
+	}
+}
+
+// badgeChecker 개별 뱃지 체커 정의
+type badgeChecker struct {
+	code    string
+	trigger BadgeGrantEvent
+	check   func(ctx context.Context, g *badgeGranterImpl, userID int64) (bool, error)
+}
+
+// registeredCheckers 등록된 모든 뱃지 체커
+var registeredCheckers = []badgeChecker{
+	{
+		code:    "FIRST_MEAL",
+		trigger: EventMealCreated,
+		check:   checkFirstMeal,
+	},
+	{
+		code:    "THREE_MEALS_A_DAY",
+		trigger: EventMealCreated,
+		check:   checkThreeMealsADay,
+	},
+	{
+		code:    "STREAK_7",
+		trigger: EventMealCreated,
+		check: func(ctx context.Context, g *badgeGranterImpl, userID int64) (bool, error) {
+			return g.checkStreak(userID, 7)
+		},
+	},
+	{
+		code:    "STREAK_30",
+		trigger: EventMealCreated,
+		check: func(ctx context.Context, g *badgeGranterImpl, userID int64) (bool, error) {
+			return g.checkStreak(userID, 30)
+		},
+	},
+	{
+		code:    "MENU_EXPLORER",
+		trigger: EventMealCreated,
+		check:   checkMenuExplorer,
+	},
+	{
+		code:    "BALANCE_MASTER",
+		trigger: EventAppearanceRecalculated,
+		check:   checkBalanceMaster,
+	},
+	{
+		code:    "COLLECTION_50",
+		trigger: EventAppearanceRecalculated,
+		check: func(ctx context.Context, g *badgeGranterImpl, userID int64) (bool, error) {
+			return g.checkCollectionCount(userID, 50)
+		},
+	},
+	{
+		code:    "COLLECTION_ALL",
+		trigger: EventAppearanceRecalculated,
+		check: func(ctx context.Context, g *badgeGranterImpl, userID int64) (bool, error) {
+			return g.checkCollectionCount(userID, totalAppearanceCombinations)
+		},
+	},
+}
+
+// CheckAndGrant 이벤트에 해당하는 뱃지를 체크하고 부여합니다.
+func (g *badgeGranterImpl) CheckAndGrant(ctx context.Context, userID int64, event BadgeGrantEvent) ([]domain.Badge, error) {
+	var granted []domain.Badge
+
+	for _, checker := range registeredCheckers {
+		if checker.trigger != event {
+			continue
+		}
+
+		badge, err := g.badgeRepo.FindBadgeByCode(checker.code)
+		if err != nil {
+			log.Printf("[BadgeGranter] FindBadgeByCode(%s) 오류: %v", checker.code, err)
+			continue
+		}
+		if badge == nil {
+			// 시드 데이터에 뱃지가 없으면 스킵
+			continue
+		}
+
+		// 이미 보유한 뱃지면 스킵
+		existing, err := g.badgeRepo.FindUserBadgeByID(userID, badge.ID)
+		if err != nil {
+			log.Printf("[BadgeGranter] FindUserBadgeByID(user=%d, badge=%s) 오류: %v", userID, checker.code, err)
+			continue
+		}
+		if existing != nil {
+			continue
+		}
+
+		// 조건 체크
+		ok, err := checker.check(ctx, g, userID)
+		if err != nil {
+			log.Printf("[BadgeGranter] 조건 체크(%s, user=%d) 오류: %v", checker.code, userID, err)
+			continue
+		}
+		if !ok {
+			continue
+		}
+
+		// 뱃지 부여
+		userBadge := &domain.UserBadge{
+			UserID:     userID,
+			BadgeID:    badge.ID,
+			AcquiredAt: time.Now(),
+		}
+		if err := g.badgeRepo.CreateUserBadge(userBadge); err != nil {
+			log.Printf("[BadgeGranter] CreateUserBadge(%s, user=%d) 오류: %v", checker.code, userID, err)
+			continue
+		}
+
+		granted = append(granted, *badge)
+		log.Printf("[BadgeGranter] 뱃지 부여: code=%s, userID=%d", checker.code, userID)
+	}
+
+	return granted, nil
+}
+
+// --- 개별 체커 함수 ---
+
+// checkFirstMeal 첫 식사 기록 뱃지
+func checkFirstMeal(_ context.Context, g *badgeGranterImpl, userID int64) (bool, error) {
+	count, err := g.mealRepo.CountByUserID(userID)
+	if err != nil {
+		return false, err
+	}
+	return count == 1, nil
+}
+
+// checkThreeMealsADay 하루 3끼 완료 뱃지
+func checkThreeMealsADay(_ context.Context, g *badgeGranterImpl, userID int64) (bool, error) {
+	today := mealDate(time.Now())
+	intake, err := g.dailyRepo.FindByUserIDAndDate(userID, today)
+	if err != nil {
+		return false, err
+	}
+	if intake == nil {
+		return false, nil
+	}
+	return intake.MealCount >= 3, nil
+}
+
+// checkMenuExplorer 서로 다른 메뉴 50종 기록 뱃지
+func checkMenuExplorer(_ context.Context, g *badgeGranterImpl, userID int64) (bool, error) {
+	count, err := g.mealRepo.CountDistinctMenuByUserID(userID)
+	if err != nil {
+		return false, err
+	}
+	return count >= 50, nil
+}
+
+// checkBalanceMaster 영양 밸런스 7일 연속 달성 뱃지
+// daily_intakes.is_balanced 는 AppearanceRecalculate Cron(05:10)에서 설정됩니다.
+func checkBalanceMaster(_ context.Context, g *badgeGranterImpl, userID int64) (bool, error) {
+	intakes, err := g.dailyRepo.FindRecentByUserID(userID, 7)
+	if err != nil {
+		return false, err
+	}
+	if len(intakes) < 7 {
+		return false, nil
+	}
+
+	today := mealDate(time.Now())
+	for i, di := range intakes {
+		expected := today.AddDate(0, 0, -i)
+		diDate := time.Date(di.Date.Year(), di.Date.Month(), di.Date.Day(), 0, 0, 0, 0, time.UTC)
+		if !diDate.Equal(expected) || !di.IsBalanced {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// checkStreak N일 연속 기록 뱃지 (STREAK_7, STREAK_30 공용)
+func (g *badgeGranterImpl) checkStreak(userID int64, days int) (bool, error) {
+	intakes, err := g.dailyRepo.FindRecentByUserID(userID, days)
+	if err != nil {
+		return false, err
+	}
+	if len(intakes) < days {
+		return false, nil
+	}
+
+	today := mealDate(time.Now())
+	for i, di := range intakes {
+		expected := today.AddDate(0, 0, -i)
+		diDate := time.Date(di.Date.Year(), di.Date.Month(), di.Date.Day(), 0, 0, 0, 0, time.UTC)
+		if !diDate.Equal(expected) || di.MealCount == 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// checkCollectionCount 먹찌 도감 N종 달성 뱃지 (COLLECTION_50, COLLECTION_ALL 공용)
+func (g *badgeGranterImpl) checkCollectionCount(userID int64, target int64) (bool, error) {
+	count, err := g.collectionRepo.CountByUserID(userID)
+	if err != nil {
+		return false, err
+	}
+	return count >= target, nil
+}
+
+// mealDate KST 05:00 기준으로 식사 날짜를 반환합니다.
+func mealDate(t time.Time) time.Time {
+	kst := time.FixedZone("KST", 9*60*60)
+	now := t.In(kst)
+	if now.Hour() < 5 {
+		now = now.AddDate(0, 0, -1)
+	}
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/backend/internal/usecase/badge_test.go
+++ b/backend/internal/usecase/badge_test.go
@@ -51,6 +51,14 @@ func (m *MockBadgeRepository) FindUserBadgeByID(userID, badgeID int64) (*domain.
 	return args.Get(0).(*domain.UserBadge), args.Error(1)
 }
 
+func (m *MockBadgeRepository) FindBadgeByCode(code string) (*domain.Badge, error) {
+	args := m.Called(code)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Badge), args.Error(1)
+}
+
 func TestBadgeUsecase_GetBadges(t *testing.T) {
 	mockRepo := new(MockBadgeRepository)
 	uc := NewBadgeUsecase(mockRepo)

--- a/backend/internal/usecase/character_collection.go
+++ b/backend/internal/usecase/character_collection.go
@@ -1,0 +1,33 @@
+package usecase
+
+import (
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/repository"
+)
+
+// CharacterCollectionUsecase 먹찌 도감 유즈케이스 인터페이스
+type CharacterCollectionUsecase interface {
+	GetCharacterCollections(userID int64, page, limit int) ([]domain.CharacterCollection, int64, error)
+}
+
+type characterCollectionUsecaseImpl struct {
+	repo repository.CharacterCollectionRepository
+}
+
+func NewCharacterCollectionUsecase(repo repository.CharacterCollectionRepository) CharacterCollectionUsecase {
+	return &characterCollectionUsecaseImpl{repo: repo}
+}
+
+func (u *characterCollectionUsecaseImpl) GetCharacterCollections(userID int64, page, limit int) ([]domain.CharacterCollection, int64, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if page <= 0 {
+		page = 1
+	}
+	offset := (page - 1) * limit
+	return u.repo.FindByUserID(userID, limit, offset)
+}

--- a/backend/internal/usecase/mastery.go
+++ b/backend/internal/usecase/mastery.go
@@ -1,0 +1,71 @@
+package usecase
+
+import (
+	"fmt"
+
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/repository"
+)
+
+// MasteryError 마스터리 관련 에러
+type MasteryError struct {
+	Code    string
+	Message string
+	Details string
+}
+
+func (e *MasteryError) Error() string {
+	return fmt.Sprintf("[%s] %s: %s", e.Code, e.Message, e.Details)
+}
+
+// MasteryUsecase 마스터리 유즈케이스 인터페이스
+type MasteryUsecase interface {
+	// GetMasteries 사용자의 마스터리 목록 조회
+	GetMasteries(userID int64, page, limit int) ([]domain.Mastery, int64, error)
+
+	// GetMasteryByMenu 특정 메뉴의 마스터리 상세 조회
+	GetMasteryByMenu(userID, menuID int64) (*domain.Mastery, error)
+}
+
+type masteryUsecaseImpl struct {
+	masteryRepo repository.MasteryRepository
+}
+
+func NewMasteryUsecase(masteryRepo repository.MasteryRepository) MasteryUsecase {
+	return &masteryUsecaseImpl{masteryRepo: masteryRepo}
+}
+
+func (u *masteryUsecaseImpl) GetMasteries(userID int64, page, limit int) ([]domain.Mastery, int64, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	if page <= 0 {
+		page = 1
+	}
+	offset := (page - 1) * limit
+
+	masteries, total, err := u.masteryRepo.FindByUserID(userID, limit, offset)
+	if err != nil {
+		return nil, 0, &MasteryError{
+			Code:    "MASTERY_FETCH_ERROR",
+			Message: "마스터리 목록을 조회하는 중에 오류가 발생했습니다.",
+			Details: err.Error(),
+		}
+	}
+	return masteries, total, nil
+}
+
+func (u *masteryUsecaseImpl) GetMasteryByMenu(userID, menuID int64) (*domain.Mastery, error) {
+	mastery, err := u.masteryRepo.FindByUserIDAndMenuID(userID, menuID)
+	if err != nil {
+		return nil, &MasteryError{
+			Code:    "MASTERY_FETCH_ERROR",
+			Message: "마스터리 정보를 조회하는 중에 오류가 발생했습니다.",
+			Details: err.Error(),
+		}
+	}
+	return mastery, nil
+}

--- a/backend/internal/usecase/mastery_tracker.go
+++ b/backend/internal/usecase/mastery_tracker.go
@@ -1,0 +1,59 @@
+package usecase
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/repository"
+)
+
+// MasteryTracker 마스터리 자동 갱신 인터페이스
+type MasteryTracker interface {
+	// OnMealCreated 식사 기록 생성 시 마스터리 eat_count를 증가시키고 grade를 갱신합니다.
+	// 등급이 변경된 경우 변경 후 Mastery를 반환하며, 그렇지 않으면 nil을 반환합니다.
+	OnMealCreated(ctx context.Context, userID, menuID int64) (*domain.Mastery, error)
+}
+
+type masteryTrackerImpl struct {
+	masteryRepo repository.MasteryRepository
+}
+
+func NewMasteryTracker(masteryRepo repository.MasteryRepository) MasteryTracker {
+	return &masteryTrackerImpl{masteryRepo: masteryRepo}
+}
+
+func (t *masteryTrackerImpl) OnMealCreated(_ context.Context, userID, menuID int64) (*domain.Mastery, error) {
+	// menuID가 없는 수동 입력 식사는 마스터리 갱신 대상 아님
+	if menuID == 0 {
+		return nil, nil
+	}
+
+	prevGrade := domain.MasteryGrade("")
+
+	// 기존 마스터리 조회 (등급 변경 감지용)
+	existing, err := t.masteryRepo.FindByUserIDAndMenuID(userID, menuID)
+	if err != nil {
+		log.Printf("[MasteryTracker] FindByUserIDAndMenuID(user=%d, menu=%d) 오류: %v", userID, menuID, err)
+		return nil, err
+	}
+	if existing != nil {
+		prevGrade = existing.Grade
+	}
+
+	updated, err := t.masteryRepo.Upsert(userID, menuID, time.Now())
+	if err != nil {
+		log.Printf("[MasteryTracker] Upsert(user=%d, menu=%d) 오류: %v", userID, menuID, err)
+		return nil, err
+	}
+
+	// 등급이 변경된 경우에만 반환 (호출자가 알림/뱃지 처리에 활용)
+	if updated.Grade != prevGrade {
+		log.Printf("[MasteryTracker] 마스터리 등급 변경: user=%d, menu=%d, %s -> %s",
+			userID, menuID, prevGrade, updated.Grade)
+		return updated, nil
+	}
+
+	return nil, nil
+}

--- a/backend/internal/usecase/reward.go
+++ b/backend/internal/usecase/reward.go
@@ -1,0 +1,60 @@
+package usecase
+
+import (
+	"fmt"
+
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/repository"
+)
+
+// RewardError 보상 관련 에러
+type RewardError struct {
+	Code    string
+	Message string
+	Details string
+}
+
+func (e *RewardError) Error() string {
+	return fmt.Sprintf("[%s] %s: %s", e.Code, e.Message, e.Details)
+}
+
+// RewardUsecase 보상 유즈케이스 인터페이스
+type RewardUsecase interface {
+	// GetRewards 전체 보상 아이템 목록 조회 (획득/미획득 포함)
+	GetRewards(userID int64) ([]domain.Reward, map[int64]*domain.UserReward, error)
+}
+
+type rewardUsecaseImpl struct {
+	rewardRepo repository.RewardRepository
+}
+
+func NewRewardUsecase(rewardRepo repository.RewardRepository) RewardUsecase {
+	return &rewardUsecaseImpl{rewardRepo: rewardRepo}
+}
+
+func (u *rewardUsecaseImpl) GetRewards(userID int64) ([]domain.Reward, map[int64]*domain.UserReward, error) {
+	rewards, err := u.rewardRepo.FindAll()
+	if err != nil {
+		return nil, nil, &RewardError{
+			Code:    "REWARD_FETCH_ERROR",
+			Message: "보상 목록을 조회하는 중에 오류가 발생했습니다.",
+			Details: err.Error(),
+		}
+	}
+
+	userRewards, err := u.rewardRepo.FindUserRewards(userID)
+	if err != nil {
+		return nil, nil, &RewardError{
+			Code:    "USER_REWARD_FETCH_ERROR",
+			Message: "사용자의 보상 정보를 조회하는 중에 오류가 발생했습니다.",
+			Details: err.Error(),
+		}
+	}
+
+	acquiredMap := make(map[int64]*domain.UserReward, len(userRewards))
+	for i := range userRewards {
+		acquiredMap[userRewards[i].RewardID] = &userRewards[i]
+	}
+
+	return rewards, acquiredMap, nil
+}

--- a/backend/internal/usecase/title.go
+++ b/backend/internal/usecase/title.go
@@ -1,0 +1,103 @@
+package usecase
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/domain"
+	"github.com/SeoHyeokGyu/Mukzzi/backend/internal/repository"
+)
+
+// TitleError 칭호 관련 에러
+type TitleError struct {
+	Code    string
+	Message string
+	Details string
+}
+
+func (e *TitleError) Error() string {
+	return fmt.Sprintf("[%s] %s: %s", e.Code, e.Message, e.Details)
+}
+
+// ErrTitleNotOwned 보유하지 않은 칭호 장착 시도
+var ErrTitleNotOwned = errors.New("보유하지 않은 칭호입니다")
+
+// TitleUsecase 칭호 유즈케이스 인터페이스
+type TitleUsecase interface {
+	// GetTitles 전체 칭호 목록 조회 (획득/미획득 포함)
+	GetTitles(userID int64) ([]domain.Title, map[int64]*domain.UserTitle, *int64, error)
+
+	// EquipTitle 칭호 장착 또는 해제 (titleID nil이면 해제)
+	EquipTitle(userID int64, titleID *int64) error
+}
+
+type titleUsecaseImpl struct {
+	titleRepo repository.TitleRepository
+	userRepo  repository.UserRepository
+}
+
+func NewTitleUsecase(titleRepo repository.TitleRepository, userRepo repository.UserRepository) TitleUsecase {
+	return &titleUsecaseImpl{
+		titleRepo: titleRepo,
+		userRepo:  userRepo,
+	}
+}
+
+func (u *titleUsecaseImpl) GetTitles(userID int64) ([]domain.Title, map[int64]*domain.UserTitle, *int64, error) {
+	titles, err := u.titleRepo.FindAll()
+	if err != nil {
+		return nil, nil, nil, &TitleError{
+			Code:    "TITLE_FETCH_ERROR",
+			Message: "칭호 목록을 조회하는 중에 오류가 발생했습니다.",
+			Details: err.Error(),
+		}
+	}
+
+	userTitles, err := u.titleRepo.FindUserTitles(userID)
+	if err != nil {
+		return nil, nil, nil, &TitleError{
+			Code:    "USER_TITLE_FETCH_ERROR",
+			Message: "사용자의 칭호 정보를 조회하는 중에 오류가 발생했습니다.",
+			Details: err.Error(),
+		}
+	}
+
+	acquiredMap := make(map[int64]*domain.UserTitle, len(userTitles))
+	for i := range userTitles {
+		acquiredMap[userTitles[i].TitleID] = &userTitles[i]
+	}
+
+	// 현재 장착 중인 칭호 ID
+	user, err := u.userRepo.GetByID(userID)
+	if err != nil {
+		return nil, nil, nil, &TitleError{
+			Code:    "USER_FETCH_ERROR",
+			Message: "사용자 정보를 조회하는 중에 오류가 발생했습니다.",
+			Details: err.Error(),
+		}
+	}
+
+	return titles, acquiredMap, user.EquippedTitleID, nil
+}
+
+func (u *titleUsecaseImpl) EquipTitle(userID int64, titleID *int64) error {
+	// 해제 요청이면 바로 처리
+	if titleID == nil {
+		return u.userRepo.UpdateEquippedTitle(userID, nil)
+	}
+
+	// 보유 여부 확인
+	userTitle, err := u.titleRepo.FindUserTitleByID(userID, *titleID)
+	if err != nil {
+		return &TitleError{
+			Code:    "TITLE_FETCH_ERROR",
+			Message: "칭호 정보를 조회하는 중에 오류가 발생했습니다.",
+			Details: err.Error(),
+		}
+	}
+	if userTitle == nil {
+		return ErrTitleNotOwned
+	}
+
+	return u.userRepo.UpdateEquippedTitle(userID, titleID)
+}


### PR DESCRIPTION
## Summary

- `BadgeGranter` 구현: 8가지 뱃지 조건 자동 체크 및 부여 (MEAL_CREATED / APPEARANCE_RECALCULATED 이벤트)
- `Mastery`, `Title`, `UserTitle`, `Reward`, `UserReward` 도메인 엔티티 추가
- 컬렉션 도메인 Repository, Usecase, API 전체 구현

## 추가된 엔드포인트

| Method | Endpoint | 설명 |
|--------|----------|------|
| GET | `/api/collections/badges` | 뱃지 목록 (커서 페이지네이션) |
| GET | `/api/collections/characters` | 먹찌 도감 |
| GET | `/api/collections/mastery` | 마스터리 목록 |
| GET | `/api/collections/mastery/:menuId` | 특정 메뉴 마스터리 상세 |
| GET | `/api/collections/titles` | 칭호 목록 |
| PATCH | `/api/collections/titles/equip` | 칭호 장착/해제 |
| GET | `/api/collections/rewards` | 보상 아이템 목록 |

## Test plan

- [ ] `go build ./...` 빌드 통과 확인
- [ ] `go test ./...` 전체 테스트 통과 확인
- [ ] `GET /api/collections/badges` 응답 구조 확인
- [ ] `PATCH /api/collections/titles/equip` 보유하지 않은 칭호 장착 시 400 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)