### PR TITLE
feat: API 연동 - 캐릭터/영양/식사 더미 데이터 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Claude Code (local only)
 CLAUDE.md
+.handoff/workspace.env
+.handoff/gemini_ws.env
+.handoff/claude_ws.env
 
 # Environment
 .env
@@ -28,9 +31,25 @@ frontend/.fvm/
 # macOS
 .DS_Store
 
+# Generated output / temp
+output/
+ws_list.txt
+frontend/assets/animations_backup/
+
+scripts/
+
+# Agent workflow files
+SHARED.md
+GEMINI.md
+.handoff/
+docs/VERIFICATION_LOG.md
+
 # Node (if any tooling)
 node_modules/
 
 # Docker
 *.log
 backend/tmp/
+.handoff/workspace.env
+.handoff/archive/
+.handoff/archive/

--- a/frontend/lib/src/core/constants/app_constants.dart
+++ b/frontend/lib/src/core/constants/app_constants.dart
@@ -37,6 +37,8 @@ class AppConstants {
   static const int maxFriendsCount = 100;
   static const double minServingSize = 0.5;
   static const double maxServingSize = 3.0;
+  static const double xpGoalPerLevel = 100.0;
+  static const double defaultDailyCalorieGoal = 2000.0;
 
   // App Info
   static const String appVersion = '1.0.0';

--- a/frontend/lib/src/features/character/data/models/character_model.dart
+++ b/frontend/lib/src/features/character/data/models/character_model.dart
@@ -1,4 +1,5 @@
 import '../../../../core/widgets/mukzzi_character.dart';
+import '../../domain/models/reward_model.dart';
 
 class CharacterModel {
   final String id;
@@ -13,6 +14,8 @@ class CharacterModel {
   final int muscle;
   final int skinTone;
   final int expression;
+  final RewardModel? equippedBackground;
+  final RewardModel? equippedAccessory;
 
   CharacterModel({
     required this.id,
@@ -27,6 +30,8 @@ class CharacterModel {
     required this.muscle,
     required this.skinTone,
     required this.expression,
+    this.equippedBackground,
+    this.equippedAccessory,
   });
 
   factory CharacterModel.fromJson(Map<String, dynamic> json) {
@@ -34,6 +39,7 @@ class CharacterModel {
     final penalty = json['penalty_status'] as String? ?? 'NORMAL';
     if (penalty == 'HUNGRY') status = CharacterState.hungry;
     if (penalty == 'STARVING') status = CharacterState.starving;
+    // 'WEAKENED' is mapped to 'sleeping' state as a visual fallback
     if (penalty == 'WEAKENED') status = CharacterState.sleeping;
 
     return CharacterModel(
@@ -49,6 +55,12 @@ class CharacterModel {
       muscle: json['muscle'] as int? ?? 0,
       skinTone: json['skin_tone'] as int? ?? 0,
       expression: json['expression'] as int? ?? 0,
+      equippedBackground: json['equipped_background'] != null
+          ? RewardModel.fromJson(json['equipped_background'] as Map<String, dynamic>)
+          : null,
+      equippedAccessory: json['equipped_accessory'] != null
+          ? RewardModel.fromJson(json['equipped_accessory'] as Map<String, dynamic>)
+          : null,
     );
   }
 

--- a/frontend/lib/src/features/character/data/repositories/character_repository.dart
+++ b/frontend/lib/src/features/character/data/repositories/character_repository.dart
@@ -8,6 +8,9 @@ class CharacterRepository {
 
   Future<CharacterModel> getMyCharacter() async {
     final response = await _apiClient.get('/users/me/character');
+    if (response == null || response['data'] == null) {
+      throw Exception('캐릭터 정보를 불러올 수 없습니다.');
+    }
     return CharacterModel.fromJson(response['data'] as Map<String, dynamic>);
   }
 

--- a/frontend/lib/src/features/character/presentation/pages/character_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/character_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 // import 'package:lottie/lottie.dart'; // mukzzi.json 추가 시 활성화
+import '../../../../core/constants/app_constants.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/gradient_scaffold.dart';
 import '../../../../core/widgets/bento_card.dart';
@@ -20,7 +21,7 @@ class CharacterPage extends ConsumerWidget {
 
     final level = char?.level ?? 1;
     final xp = char?.exp.toDouble() ?? 0.0;
-    const xpGoal = 100.0;
+    const xpGoal = AppConstants.xpGoalPerLevel;
     final state = char?.state ?? CharacterState.normal;
     final evolutionLabel = char?.evolutionLabel ?? '부화 단계';
 
@@ -104,25 +105,6 @@ class CharacterPage extends ConsumerWidget {
                 ],
               ),
             ),
-            const SizedBox(height: 16),
-
-            // 스탯 그리드
-            Text('스탯', style: _sectionStyle(context, tokens)),
-            const SizedBox(height: 10),
-            GridView.count(
-              crossAxisCount: 2,
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              childAspectRatio: 1.6,
-              mainAxisSpacing: 10,
-              crossAxisSpacing: 10,
-              children: [
-                _StatProgressTile(label: '포만감',    value: 68, color: tokens.primary,      icon: Icons.restaurant_outlined, tokens: tokens),
-                _StatProgressTile(label: '활력',     value: 82, color: const Color(0xFF3DD68C), icon: Icons.bolt_outlined,       tokens: tokens),
-                _StatProgressTile(label: '영양균형',  value: 74, color: const Color(0xFF7BD3FF), icon: Icons.favorite_outline,    tokens: tokens),
-                _StatProgressTile(label: '친밀도',   value: 91, color: const Color(0xFFFF8FA3), icon: Icons.star_outline,         tokens: tokens),
-              ],
-            ),
             const SizedBox(height: 24),
 
             // 진화 단계
@@ -162,9 +144,19 @@ class CharacterPage extends ConsumerWidget {
                     tokens: tokens,
                   ),
                   Divider(height: 1, color: tokens.primary.withValues(alpha: 0.08)),
-                  _EquipmentItem(label: '배경',    value: '빈 방', onTap: () => context.push('/character/rewards'), tokens: tokens),
+                  _EquipmentItem(
+                    label: '배경',
+                    value: char?.equippedBackground?.name ?? '기본 배경',
+                    onTap: () => context.push('/character/rewards'),
+                    tokens: tokens,
+                  ),
                   Divider(height: 1, color: tokens.primary.withValues(alpha: 0.08)),
-                  _EquipmentItem(label: '악세서리', value: '없음',  onTap: () => context.push('/character/rewards'), tokens: tokens),
+                  _EquipmentItem(
+                    label: '악세서리',
+                    value: char?.equippedAccessory?.name ?? '없음',
+                    onTap: () => context.push('/character/rewards'),
+                    tokens: tokens,
+                  ),
                 ],
               ),
             ),
@@ -227,78 +219,6 @@ class CharacterPage extends ConsumerWidget {
       child: Text(
         state.label,
         style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w700, color: Color(0xFF1A1A1A)),
-      ),
-    );
-  }
-}
-
-class _StatProgressTile extends StatelessWidget {
-  final String label;
-  final int value;
-  final Color color;
-  final IconData icon;
-  final AppColorTokens tokens;
-
-  const _StatProgressTile({
-    required this.label,
-    required this.value,
-    required this.color,
-    required this.icon,
-    required this.tokens,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return BentoCard(
-      borderRadius: BorderRadius.circular(tokens.rCard),
-      padding: const EdgeInsets.all(14),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Row(
-            children: [
-              Container(
-                width: 28,
-                height: 28,
-                decoration: BoxDecoration(
-                  color: color.withValues(alpha: 0.14),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Icon(icon, size: 14, color: color),
-              ),
-              const SizedBox(width: 8),
-              Text(label, style: TextStyle(fontSize: 12, color: tokens.textSub, fontWeight: FontWeight.w500)),
-            ],
-          ),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              RichText(
-                text: TextSpan(children: [
-                  TextSpan(
-                    text: '$value',
-                    style: GoogleFonts.poppins(fontSize: 22, fontWeight: FontWeight.w800, color: tokens.textPrimary),
-                  ),
-                  TextSpan(
-                    text: '/100',
-                    style: TextStyle(fontSize: 11, color: tokens.textMuted),
-                  ),
-                ]),
-              ),
-              const SizedBox(height: 6),
-              ClipRRect(
-                borderRadius: BorderRadius.circular(3),
-                child: LinearProgressIndicator(
-                  value: value / 100,
-                  minHeight: 4,
-                  backgroundColor: tokens.primary.withValues(alpha: 0.1),
-                  valueColor: AlwaysStoppedAnimation<Color>(color),
-                ),
-              ),
-            ],
-          ),
-        ],
       ),
     );
   }

--- a/frontend/lib/src/features/character/presentation/providers/character_provider.dart
+++ b/frontend/lib/src/features/character/presentation/providers/character_provider.dart
@@ -8,5 +8,5 @@ final characterRepositoryProvider = Provider<CharacterRepository>((ref) {
 });
 
 final characterProvider = FutureProvider.autoDispose<CharacterModel>((ref) async {
-  return ref.watch(characterRepositoryProvider).getMyCharacter();
+  return ref.read(characterRepositoryProvider).getMyCharacter();
 });

--- a/frontend/lib/src/features/home/data/models/nutrition_model.dart
+++ b/frontend/lib/src/features/home/data/models/nutrition_model.dart
@@ -1,0 +1,104 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'nutrition_model.g.dart';
+
+@JsonSerializable()
+class DailyNutritionModel {
+  final String date;
+  @JsonKey(name: 'total_calories')
+  final double totalCalories;
+  @JsonKey(name: 'total_carbs')
+  final double totalCarbs;
+  @JsonKey(name: 'total_protein')
+  final double totalProtein;
+  @JsonKey(name: 'total_fat')
+  final double totalFat;
+  @JsonKey(name: 'total_sodium')
+  final double totalSodium;
+  @JsonKey(name: 'total_fiber')
+  final double totalFiber;
+  @JsonKey(name: 'meal_count')
+  final int mealCount;
+  @JsonKey(name: 'last_calculated_at')
+  final DateTime lastCalculatedAt;
+  @JsonKey(name: 'nutrition_goal')
+  final NutritionGoalModel? nutritionGoal;
+
+  DailyNutritionModel({
+    required this.date,
+    required this.totalCalories,
+    required this.totalCarbs,
+    required this.totalProtein,
+    required this.totalFat,
+    required this.totalSodium,
+    required this.totalFiber,
+    required this.mealCount,
+    required this.lastCalculatedAt,
+    this.nutritionGoal,
+  });
+
+  factory DailyNutritionModel.empty() {
+    return DailyNutritionModel(
+      date: DateTime.now().toIso8601String().split('T')[0],
+      totalCalories: 0,
+      totalCarbs: 0,
+      totalProtein: 0,
+      totalFat: 0,
+      totalSodium: 0,
+      totalFiber: 0,
+      mealCount: 0,
+      lastCalculatedAt: DateTime.now(),
+    );
+  }
+
+  factory DailyNutritionModel.fromJson(Map<String, dynamic> json) =>
+      _$DailyNutritionModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DailyNutritionModelToJson(this);
+}
+
+@JsonSerializable()
+class WeeklyNutritionItemModel {
+  final String date;
+  final double calories;
+  final double carbs;
+  final double protein;
+  final double fat;
+
+  WeeklyNutritionItemModel({
+    required this.date,
+    required this.calories,
+    required this.carbs,
+    required this.protein,
+    required this.fat,
+  });
+
+  factory WeeklyNutritionItemModel.fromJson(Map<String, dynamic> json) =>
+      _$WeeklyNutritionItemModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$WeeklyNutritionItemModelToJson(this);
+}
+
+@JsonSerializable()
+class NutritionGoalModel {
+  @JsonKey(name: 'calorie_goal')
+  final double calorieGoal;
+  @JsonKey(name: 'carb_goal')
+  final double carbGoal;
+  @JsonKey(name: 'protein_goal')
+  final double proteinGoal;
+  @JsonKey(name: 'fat_goal')
+  final double fatGoal;
+
+  NutritionGoalModel({
+    required this.calorieGoal,
+    required this.carbGoal,
+    required this.proteinGoal,
+    required this.fatGoal,
+  });
+
+  factory NutritionGoalModel.fromJson(Map<String, dynamic> json) =>
+      _$NutritionGoalModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$NutritionGoalModelToJson(this);
+}

--- a/frontend/lib/src/features/home/data/models/nutrition_model.g.dart
+++ b/frontend/lib/src/features/home/data/models/nutrition_model.g.dart
@@ -1,0 +1,75 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'nutrition_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DailyNutritionModel _$DailyNutritionModelFromJson(Map<String, dynamic> json) =>
+    DailyNutritionModel(
+      date: json['date'] as String,
+      totalCalories: (json['total_calories'] as num).toDouble(),
+      totalCarbs: (json['total_carbs'] as num).toDouble(),
+      totalProtein: (json['total_protein'] as num).toDouble(),
+      totalFat: (json['total_fat'] as num).toDouble(),
+      totalSodium: (json['total_sodium'] as num).toDouble(),
+      totalFiber: (json['total_fiber'] as num).toDouble(),
+      mealCount: (json['meal_count'] as num).toInt(),
+      lastCalculatedAt: DateTime.parse(json['last_calculated_at'] as String),
+      nutritionGoal: json['nutrition_goal'] == null
+          ? null
+          : NutritionGoalModel.fromJson(
+              json['nutrition_goal'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$DailyNutritionModelToJson(
+        DailyNutritionModel instance) =>
+    <String, dynamic>{
+      'date': instance.date,
+      'total_calories': instance.totalCalories,
+      'total_carbs': instance.totalCarbs,
+      'total_protein': instance.totalProtein,
+      'total_fat': instance.totalFat,
+      'total_sodium': instance.totalSodium,
+      'total_fiber': instance.totalFiber,
+      'meal_count': instance.mealCount,
+      'last_calculated_at': instance.lastCalculatedAt.toIso8601String(),
+      'nutrition_goal': instance.nutritionGoal,
+    };
+
+WeeklyNutritionItemModel _$WeeklyNutritionItemModelFromJson(
+        Map<String, dynamic> json) =>
+    WeeklyNutritionItemModel(
+      date: json['date'] as String,
+      calories: (json['calories'] as num).toDouble(),
+      carbs: (json['carbs'] as num).toDouble(),
+      protein: (json['protein'] as num).toDouble(),
+      fat: (json['fat'] as num).toDouble(),
+    );
+
+Map<String, dynamic> _$WeeklyNutritionItemModelToJson(
+        WeeklyNutritionItemModel instance) =>
+    <String, dynamic>{
+      'date': instance.date,
+      'calories': instance.calories,
+      'carbs': instance.carbs,
+      'protein': instance.protein,
+      'fat': instance.fat,
+    };
+
+NutritionGoalModel _$NutritionGoalModelFromJson(Map<String, dynamic> json) =>
+    NutritionGoalModel(
+      calorieGoal: (json['calorie_goal'] as num).toDouble(),
+      carbGoal: (json['carb_goal'] as num).toDouble(),
+      proteinGoal: (json['protein_goal'] as num).toDouble(),
+      fatGoal: (json['fat_goal'] as num).toDouble(),
+    );
+
+Map<String, dynamic> _$NutritionGoalModelToJson(NutritionGoalModel instance) =>
+    <String, dynamic>{
+      'calorie_goal': instance.calorieGoal,
+      'carb_goal': instance.carbGoal,
+      'protein_goal': instance.proteinGoal,
+      'fat_goal': instance.fatGoal,
+    };

--- a/frontend/lib/src/features/home/data/repositories/nutrition_repository.dart
+++ b/frontend/lib/src/features/home/data/repositories/nutrition_repository.dart
@@ -1,0 +1,27 @@
+import '../../../../core/network/api_client.dart';
+import '../models/nutrition_model.dart';
+
+class NutritionRepository {
+  final ApiClient _apiClient;
+
+  NutritionRepository(this._apiClient);
+
+  Future<DailyNutritionModel> getTodayNutrition() async {
+    final response = await _apiClient.get('/nutrition/today');
+    if (response == null || response['data'] == null) {
+      return DailyNutritionModel.empty();
+    }
+    return DailyNutritionModel.fromJson(response['data'] as Map<String, dynamic>);
+  }
+
+  Future<List<WeeklyNutritionItemModel>> getWeeklyNutrition() async {
+    final response = await _apiClient.get('/nutrition/weekly');
+    if (response == null || response['data'] == null) {
+      return [];
+    }
+    
+    return (response['data'] as List<dynamic>)
+        .map((e) => WeeklyNutritionItemModel.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/frontend/lib/src/features/home/presentation/pages/home_page.dart
+++ b/frontend/lib/src/features/home/presentation/pages/home_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
+import 'package:mukzzi/src/core/constants/app_constants.dart';
 import 'package:mukzzi/src/core/theme/app_theme.dart';
 import 'package:mukzzi/src/core/widgets/bento_card.dart';
 import 'package:mukzzi/src/core/widgets/gradient_scaffold.dart';
@@ -17,26 +18,12 @@ import 'package:mukzzi/src/features/character/data/models/character_model.dart';
 import 'package:mukzzi/src/features/character/presentation/providers/character_provider.dart';
 import 'package:mukzzi/src/features/profile/presentation/providers/user_provider.dart';
 import 'package:mukzzi/src/features/home/presentation/widgets/menu_decision_section.dart';
+import 'package:mukzzi/src/features/home/data/models/nutrition_model.dart';
+import 'package:mukzzi/src/features/home/presentation/providers/nutrition_provider.dart';
+import 'package:mukzzi/src/features/meal_record/data/models/meal_model.dart';
+import 'package:mukzzi/src/features/meal_record/presentation/providers/meal_provider.dart';
 import 'package:mukzzi/src/features/quest/domain/entities/quest.dart';
 import 'package:mukzzi/src/features/quest/presentation/providers/quest_provider.dart';
-import 'package:showcaseview/showcaseview.dart';
-
-// Mock 데이터 - 추후 API로 교체
-const double _caloriesConsumed = 1200;
-const double _caloriesGoal = 2000;
-const double _proteinConsumed = 45;
-const double _proteinGoal = 60;
-const double _carbsConsumed = 150;
-const double _carbsGoal = 300;
-const double _fatConsumed = 30;
-const double _fatGoal = 60;
-const int _mockStreakDays = 3;
-
-const _mockMeals = [
-  (emoji: '🍚', time: '오전 8:30', name: '아침밥', kcal: 350),
-  (emoji: '🍜', time: '오후 12:00', name: '점심 국수', kcal: 520),
-  (emoji: '🍎', time: '오후 3:00', name: '간식', kcal: 80),
-];
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
@@ -311,6 +298,9 @@ class _HomePageState extends ConsumerState<HomePage> {
 
     final characterAsync = ref.watch(characterProvider);
     final dailyQuests = ref.watch(dailyQuestsProvider);
+    final nutritionAsync = ref.watch(todayNutritionProvider);
+    final weeklyNutritionAsync = ref.watch(weeklyNutritionProvider);
+    final mealsAsync = ref.watch(todayMealsProvider);
 
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -323,19 +313,101 @@ class _HomePageState extends ConsumerState<HomePage> {
             error: (_, __) => _buildHeroCard(tokens, null),
           ),
           const SizedBox(height: 12),
-          _buildStreakQuestRow(tokens, dailyQuests),
+          _buildStreakQuestRow(tokens, dailyQuests, characterAsync.asData?.value.streakDays ?? 0),
           const SizedBox(height: 12),
           _buildQuickCTAs(tokens),
           const SizedBox(height: 12),
-          _buildNutritionCard(tokens),
+          nutritionAsync.when(
+            data: (nutrition) => _buildNutritionCard(tokens, nutrition),
+            loading: () => const ShimmerCard(height: 280),
+            error: (_, __) => _buildNutritionCard(tokens, null),
+          ),
+          const SizedBox(height: 12),
+          weeklyNutritionAsync.when(
+            data: (weekly) => _buildWeeklyTrendChart(tokens, weekly),
+            loading: () => const ShimmerCard(height: 200),
+            error: (_, __) => const SizedBox.shrink(),
+          ),
           const SizedBox(height: 12),
           _animated(const MenuDecisionSection(), delay: 200.ms, slideY: true),
           const SizedBox(height: 24),
-          _buildRecentMeals(tokens),
+          mealsAsync.when(
+            data: (meals) => _buildRecentMeals(tokens, meals),
+            loading: () => const ShimmerCard(height: 100),
+            error: (_, __) => _buildRecentMeals(tokens, []),
+          ),
           const SizedBox(height: 16),
         ],
       ),
     );
+  }
+
+  Widget _buildWeeklyTrendChart(AppColorTokens tokens, List<WeeklyNutritionItemModel> weekly) {
+    if (weekly.isEmpty) return const SizedBox.shrink();
+
+    final chart = BentoCard(
+      borderRadius: BorderRadius.circular(tokens.rCard),
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '주간 영양 트렌드',
+            style: TextStyle(fontWeight: FontWeight.w700, fontSize: 14, color: tokens.textPrimary),
+          ),
+          const SizedBox(height: 20),
+          SizedBox(
+            height: 120,
+            child: LineChart(
+              LineChartData(
+                gridData: const FlGridData(show: false),
+                titlesData: FlTitlesData(
+                  leftTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                  rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                  topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                  bottomTitles: AxisTitles(
+                    sideTitles: SideTitles(
+                      showTitles: true,
+                      getTitlesWidget: (value, meta) {
+                        final index = value.toInt();
+                        if (index < 0 || index >= weekly.length) return const SizedBox.shrink();
+                        final date = DateTime.parse(weekly[index].date);
+                        return Padding(
+                          padding: const EdgeInsets.only(top: 8.0),
+                          child: Text(
+                            DateFormat('E', 'ko').format(date),
+                            style: TextStyle(fontSize: 10, color: tokens.textMuted),
+                          ),
+                        );
+                      },
+                      reservedSize: 22,
+                    ),
+                  ),
+                ),
+                borderData: FlBorderData(show: false),
+                lineBarsData: [
+                  LineChartBarData(
+                    spots: weekly.asMap().entries.map((e) {
+                      return FlSpot(e.key.toDouble(), e.value.calories);
+                    }).toList(),
+                    isCurved: true,
+                    color: tokens.primary,
+                    barWidth: 3,
+                    isStrokeCapRound: true,
+                    dotData: const FlDotData(show: false),
+                    belowBarData: BarAreaData(
+                      show: true,
+                      color: tokens.primary.withValues(alpha: 0.1),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+    return _animated(chart, delay: 180.ms, slideY: true);
   }
 
   Widget _buildHeroCard(AppColorTokens tokens, CharacterModel? char) {
@@ -343,7 +415,7 @@ class _HomePageState extends ConsumerState<HomePage> {
     final level = char?.level ?? 1;
     final name = char?.name ?? '먹찌';
     final xp = char?.exp.toDouble() ?? 0;
-    const xpGoal = 100.0;
+    const xpGoal = AppConstants.xpGoalPerLevel;
 
     final card = BentoCard(
       showPaperTexture: true,
@@ -460,7 +532,7 @@ class _HomePageState extends ConsumerState<HomePage> {
     return _animated(card, slideY: true);
   }
 
-  Widget _buildStreakQuestRow(AppColorTokens tokens, List<Quest> quests) {
+  Widget _buildStreakQuestRow(AppColorTokens tokens, List<Quest> quests, int streakDays) {
     final row = BentoCard(
       borderRadius: BorderRadius.circular(tokens.rCard),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -470,7 +542,7 @@ class _HomePageState extends ConsumerState<HomePage> {
           Icon(Icons.local_fire_department, color: tokens.primary, size: 18),
           const SizedBox(width: 4),
           Text(
-            '연속 $_mockStreakDays일',
+            '연속 $streakDays일',
             style: TextStyle(fontSize: 13, fontWeight: FontWeight.w700, color: tokens.primary),
           ),
           const SizedBox(width: 12),
@@ -613,8 +685,10 @@ class _HomePageState extends ConsumerState<HomePage> {
     return _animated(row, delay: 80.ms, slideY: true);
   }
 
-  Widget _buildNutritionCard(AppColorTokens tokens) {
-    const remaining = _caloriesGoal - _caloriesConsumed;
+  Widget _buildNutritionCard(AppColorTokens tokens, DailyNutritionModel? nutrition) {
+    final consumed = nutrition?.totalCalories ?? 0;
+    final goal = nutrition?.nutritionGoal?.calorieGoal ?? AppConstants.defaultDailyCalorieGoal;
+    final remaining = (goal - consumed).clamp(0.0, goal);
 
     return BentoCard(
       borderRadius: BorderRadius.circular(tokens.rCard),
@@ -629,7 +703,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                 style: TextStyle(fontWeight: FontWeight.w700, fontSize: 14, color: tokens.textPrimary),
               ),
               Text(
-                '${_caloriesConsumed.toInt()} / ${_caloriesGoal.toInt()} kcal',
+                '${consumed.toInt()} / ${goal.toInt()} kcal',
                 style: TextStyle(fontSize: 11, color: tokens.textSub),
               ),
             ],
@@ -648,7 +722,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                     startDegreeOffset: -90,
                     sections: [
                       PieChartSectionData(
-                        value: _caloriesConsumed,
+                        value: consumed,
                         color: tokens.primary,
                         radius: 18,
                         showTitle: false,
@@ -666,7 +740,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Text(
-                      '${_caloriesConsumed.toInt()}',
+                      '${consumed.toInt()}',
                       style: GoogleFonts.poppins(
                         fontSize: 18,
                         fontWeight: FontWeight.w800,
@@ -684,18 +758,36 @@ class _HomePageState extends ConsumerState<HomePage> {
             ),
           ),
           const SizedBox(height: 16),
-          _MacroBar(label: '탄수', consumed: _carbsConsumed, goal: _carbsGoal, color: AppColors.carbsColor, tokens: tokens),
+          _MacroBar(
+            label: '탄수',
+            consumed: nutrition?.totalCarbs ?? 0,
+            goal: nutrition?.nutritionGoal?.carbGoal ?? 300,
+            color: AppColors.carbsColor,
+            tokens: tokens,
+          ),
           const SizedBox(height: 8),
-          _MacroBar(label: '단백', consumed: _proteinConsumed, goal: _proteinGoal, color: AppColors.proteinColor, tokens: tokens),
+          _MacroBar(
+            label: '단백',
+            consumed: nutrition?.totalProtein ?? 0,
+            goal: nutrition?.nutritionGoal?.proteinGoal ?? 60,
+            color: AppColors.proteinColor,
+            tokens: tokens,
+          ),
           const SizedBox(height: 8),
-          _MacroBar(label: '지방', consumed: _fatConsumed, goal: _fatGoal, color: AppColors.fatColor, tokens: tokens),
+          _MacroBar(
+            label: '지방',
+            consumed: nutrition?.totalFat ?? 0,
+            goal: nutrition?.nutritionGoal?.fatGoal ?? 60,
+            color: AppColors.fatColor,
+            tokens: tokens,
+          ),
         ],
       ),
     );
   }
 
-  Widget _buildRecentMeals(AppColorTokens tokens) {
-    return Column(
+  Widget _buildRecentMeals(AppColorTokens tokens, List<MealRecord> meals) {
+    final col = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
@@ -723,65 +815,82 @@ class _HomePageState extends ConsumerState<HomePage> {
           ],
         ),
         const SizedBox(height: 10),
-        ...(_mockMeals.indexed.map((entry) {
-          final (i, meal) = entry;
-          return Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: BentoCard(
-              borderRadius: BorderRadius.circular(tokens.rItem),
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-              child: Row(
-                children: [
-                  Container(
-                    width: 40,
-                    height: 40,
-                    decoration: BoxDecoration(
-                      color: tokens.listItemBg,
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                    child: Center(
-                      child: Text(meal.emoji, style: const TextStyle(fontSize: 20)),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(meal.name, style: TextStyle(fontWeight: FontWeight.w600, fontSize: 14, color: tokens.textPrimary)),
-                        Text(meal.time, style: TextStyle(fontSize: 11, color: tokens.textMuted)),
-                      ],
-                    ),
-                  ),
-                  RichText(
-                    text: TextSpan(
-                      children: [
-                        TextSpan(
-                          text: '${meal.kcal}',
-                          style: GoogleFonts.poppins(
-                            fontSize: 13,
-                            fontWeight: FontWeight.w700,
-                            color: tokens.textPrimary,
-                          ),
-                        ),
-                        TextSpan(
-                          text: ' kcal',
-                          style: TextStyle(
-                            fontSize: 10,
-                            fontWeight: FontWeight.w500,
-                            color: tokens.textMuted,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
+        if (meals.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 20),
+            child: Center(
+              child: Text(
+                '아직 오늘 기록한 식사가 없어요.',
+                style: TextStyle(fontSize: 13, color: tokens.textMuted),
               ),
-            ).animate(delay: Duration(milliseconds: 240 + i * 60)).fadeIn(duration: 250.ms),
-          );
-        })),
+            ),
+          )
+        else
+          ...(meals.indexed.map((entry) {
+            final (i, meal) = entry;
+            final mealType = MealTypeHelper.fromString(meal.mealType);
+            final timeStr = DateFormat('a h:mm', 'ko').format(meal.recordedAt);
+
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: BentoCard(
+                borderRadius: BorderRadius.circular(tokens.rItem),
+                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: tokens.listItemBg,
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      child: Center(
+                        child: Icon(mealType.icon, color: tokens.primary, size: 20),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(meal.menuName,
+                              style: TextStyle(
+                                  fontWeight: FontWeight.w600, fontSize: 14, color: tokens.textPrimary)),
+                          Text(timeStr, style: TextStyle(fontSize: 11, color: tokens.textMuted)),
+                        ],
+                      ),
+                    ),
+                    RichText(
+                      text: TextSpan(
+                        children: [
+                          TextSpan(
+                            text: '${meal.calories?.toInt() ?? 0}',
+                            style: GoogleFonts.poppins(
+                              fontSize: 13,
+                              fontWeight: FontWeight.w700,
+                              color: tokens.textPrimary,
+                            ),
+                          ),
+                          TextSpan(
+                            text: ' kcal',
+                            style: TextStyle(
+                              fontSize: 10,
+                              fontWeight: FontWeight.w500,
+                              color: tokens.textMuted,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ).animate(delay: Duration(milliseconds: 240 + i * 60)).fadeIn(duration: 250.ms),
+            );
+          })),
       ],
     );
+    return _animated(col, delay: 240.ms);
   }
 }
 

--- a/frontend/lib/src/features/home/presentation/providers/nutrition_provider.dart
+++ b/frontend/lib/src/features/home/presentation/providers/nutrition_provider.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../core/providers/common_providers.dart';
+import '../../data/models/nutrition_model.dart';
+import '../../data/repositories/nutrition_repository.dart';
+
+final nutritionRepositoryProvider = Provider<NutritionRepository>((ref) {
+  return NutritionRepository(ref.watch(apiClientProvider));
+});
+
+final todayNutritionProvider = FutureProvider.autoDispose<DailyNutritionModel>((ref) async {
+  return ref.read(nutritionRepositoryProvider).getTodayNutrition();
+});
+
+final weeklyNutritionProvider = FutureProvider.autoDispose<List<WeeklyNutritionItemModel>>((ref) async {
+  return ref.read(nutritionRepositoryProvider).getWeeklyNutrition();
+});

--- a/frontend/lib/src/features/meal_record/presentation/providers/meal_provider.dart
+++ b/frontend/lib/src/features/meal_record/presentation/providers/meal_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../core/providers/common_providers.dart';
+import '../../data/models/meal_model.dart';
+import '../../data/repositories/meal_repository.dart';
+
+final mealRepositoryProvider = Provider<MealRepository>((ref) {
+  return MealRepository(ref.watch(apiClientProvider));
+});
+
+final todayMealsProvider = FutureProvider.autoDispose<List<MealRecord>>((ref) async {
+  final now = DateTime.now();
+  final today = '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+  
+  final result = await ref.read(mealRepositoryProvider).findAll(
+    MealListFilter(
+      startDate: today,
+      endDate: today,
+      limit: 10,
+    ),
+  );
+  return result.meals;
+});

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -261,10 +261,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -516,26 +516,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -564,26 +564,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -969,10 +969,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.10"
   timing:
     dependency: transitive
     description:
@@ -1001,10 +1001,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -1070,5 +1070,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.29.0"


### PR DESCRIPTION
## Summary

- 캐릭터 탭 `GET /characters/me` 실제 API 연동, 더미 데이터 제거
- 홈 화면 오늘 영양 요약 위젯 `GET /nutrition/today` 연동
- 홈 화면 주간 영양 트렌드 차트 `GET /nutrition/weekly` 연동
- 홈 화면 오늘 식사 목록 실제 `MealRecord` 데이터 연동 (`GET /meal-records/today`)

## Changes

- `nutrition_model.dart` / `nutrition_repository.dart` / `nutrition_provider.dart` 신규 추가
- `meal_provider.dart` 신규 추가
- `character_page.dart` 더미 데이터 제거, 실제 API 응답으로 교체
- `home_page.dart` mock 상수 제거, 영양/식사 provider 연결