### PR TITLE
fix: Lottie 캐릭터 렌더링 수정 및 웹 지원 추가

### DIFF
--- a/frontend/lib/src/core/widgets/lottie_web_player_stub.dart
+++ b/frontend/lib/src/core/widgets/lottie_web_player_stub.dart
@@ -1,0 +1,3 @@
+import 'package:flutter/widgets.dart';
+
+Widget buildLottieWebPlayer(String assetPath, double size) => const SizedBox.shrink();

--- a/frontend/lib/src/core/widgets/lottie_web_player_web.dart
+++ b/frontend/lib/src/core/widgets/lottie_web_player_web.dart
@@ -1,0 +1,58 @@
+import 'dart:js_interop';
+import 'dart:ui_web' as ui_web;
+import 'package:flutter/widgets.dart';
+import 'package:web/web.dart' as dom;
+
+@JS('lottie.loadAnimation')
+external JSObject _loadAnimation(JSObject config);
+
+int _viewCounter = 0;
+
+Widget buildLottieWebPlayer(String assetPath, double size) {
+  return _LottieHtmlPlayer(assetPath: assetPath, size: size);
+}
+
+class _LottieHtmlPlayer extends StatefulWidget {
+  final String assetPath;
+  final double size;
+
+  const _LottieHtmlPlayer({required this.assetPath, required this.size});
+
+  @override
+  State<_LottieHtmlPlayer> createState() => _LottieHtmlPlayerState();
+}
+
+class _LottieHtmlPlayerState extends State<_LottieHtmlPlayer> {
+  late final String _viewType;
+
+  @override
+  void initState() {
+    super.initState();
+    _viewType = 'lottie-player-${_viewCounter++}';
+
+    ui_web.platformViewRegistry.registerViewFactory(_viewType, (int viewId) {
+      final div = dom.document.createElement('div') as dom.HTMLElement;
+      div.style.width = '100%';
+      div.style.height = '100%';
+
+      _loadAnimation({
+        'container': div,
+        'renderer': 'svg',
+        'loop': true,
+        'autoplay': true,
+        'path': widget.assetPath,
+      }.jsify() as JSObject);
+
+      return div;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: widget.size,
+      height: widget.size,
+      child: HtmlElementView(viewType: _viewType),
+    );
+  }
+}

--- a/frontend/lib/src/core/widgets/mukzzi_character.dart
+++ b/frontend/lib/src/core/widgets/mukzzi_character.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
+import 'lottie_web_player_stub.dart' if (dart.library.js_interop) 'lottie_web_player_web.dart';
 
 enum CharacterState { normal, happy, hungry, starving, sleeping }
 
@@ -8,7 +10,7 @@ enum CharacterStage { baby, teen, adult }
 extension CharacterLevelExtension on int {
   CharacterStage get stage {
     if (this <= 2) return CharacterStage.baby;
-    if (this <= 6) return CharacterStage.teen;
+    if (this <= 14) return CharacterStage.teen;
     return CharacterStage.adult;
   }
 }
@@ -75,7 +77,7 @@ extension CharacterStateLabel on CharacterState {
   }
 }
 
-class MukzziCharacter extends StatefulWidget {
+class MukzziCharacter extends StatelessWidget {
   final CharacterState state;
   final double size;
   final int level;
@@ -88,48 +90,28 @@ class MukzziCharacter extends StatefulWidget {
   }) : assert(size >= 60, 'MukzziCharacter: size < 60 renders detail-loss. Use at least 80 for best results.');
 
   @override
-  State<MukzziCharacter> createState() => _MukzziCharacterState();
-}
-
-class _MukzziCharacterState extends State<MukzziCharacter> with SingleTickerProviderStateMixin {
-  late final AnimationController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = AnimationController(vsync: this);
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final stage = widget.level.stage.name.toLowerCase();
-    final stateKey = widget.state.key;
+    final stage = level.stage.name.toLowerCase();
+    final stateKey = state.key;
     final assetPath = 'assets/animations/mukzzi_${stage}_$stateKey.json';
 
+    if (kIsWeb) {
+      return buildLottieWebPlayer('assets/$assetPath', size);
+    }
+
     return SizedBox(
-      width: widget.size,
-      height: widget.size,
+      width: size,
+      height: size,
       child: Lottie.asset(
         assetPath,
-        controller: _controller,
         fit: BoxFit.contain,
-        onLoaded: (composition) {
-          _controller
-            ..duration = composition.duration
-            ..value = 1.0;
-        },
+        repeat: true,
         errorBuilder: (context, error, stackTrace) {
           return Center(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Icon(Icons.pets, size: widget.size * 0.4, color: const Color(0xFF2D6BFF)),
+                Icon(Icons.pets, size: size * 0.4, color: const Color(0xFF2D6BFF)),
                 const SizedBox(height: 4),
                 Text('Load Failed: $assetPath', style: const TextStyle(fontSize: 8, color: Colors.red)),
               ],

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -1022,7 +1022,7 @@ packages:
     source: hosted
     version: "1.2.1"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   shimmer: ^3.0.0
   fl_chart: ^0.70.0
   lottie: ^3.3.1
+  web: ^1.1.0
   showcaseview: ^5.0.2
 
 dev_dependencies:

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -12,6 +12,7 @@
   <title>mukzzi</title>
 </head>
 <body>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/lottie_preview.html
+++ b/lottie_preview.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>먹찌 캐릭터 프리뷰</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #111;
+      color: #fff;
+      font-family: -apple-system, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 24px;
+      padding: 32px;
+    }
+    h1 { font-size: 20px; font-weight: 700; color: #fff; }
+    #player {
+      width: 280px;
+      height: 280px;
+      background: #f5f5f5;
+      border-radius: 24px;
+    }
+    .selectors {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .group { display: flex; flex-direction: column; gap: 6px; align-items: center; }
+    .group label { font-size: 11px; color: #888; text-transform: uppercase; letter-spacing: 0.05em; }
+    .btn-row { display: flex; gap: 6px; }
+    button {
+      padding: 8px 14px;
+      border-radius: 8px;
+      border: 1.5px solid #333;
+      background: #1e1e1e;
+      color: #ccc;
+      cursor: pointer;
+      font-size: 13px;
+      transition: all 0.15s;
+    }
+    button:hover { background: #2a2a2a; }
+    button.active { background: #4f46e5; border-color: #4f46e5; color: #fff; }
+    #info {
+      font-size: 13px;
+      color: #666;
+    }
+  </style>
+</head>
+<body>
+  <h1>먹찌 캐릭터 프리뷰</h1>
+  <div id="player"></div>
+
+  <div class="selectors">
+    <div class="group">
+      <label>단계</label>
+      <div class="btn-row" id="stage-btns">
+        <button class="active" onclick="setStage('baby')">아기</button>
+        <button onclick="setStage('teen')">청소년</button>
+        <button onclick="setStage('adult')">성체</button>
+      </div>
+    </div>
+    <div class="group">
+      <label>상태</label>
+      <div class="btn-row" id="state-btns">
+        <button class="active" onclick="setState('idle')">idle</button>
+        <button onclick="setState('happy')">happy</button>
+        <button onclick="setState('hungry')">hungry</button>
+        <button onclick="setState('starving')">starving</button>
+        <button onclick="setState('sleeping')">sleeping</button>
+      </div>
+    </div>
+    <div class="group">
+      <label>재생</label>
+      <div class="btn-row">
+        <button onclick="anim && anim.play()">Play</button>
+        <button onclick="anim && anim.pause()">Pause</button>
+        <button onclick="anim && anim.stop()">Stop</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="info">loading...</div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>
+  <script>
+    var currentStage = 'baby';
+    var currentState = 'idle';
+    var anim = null;
+
+    function load() {
+      var path = 'frontend/assets/animations/mukzzi_' + currentStage + '_' + currentState + '.json';
+      document.getElementById('info').textContent = 'Loading: ' + path;
+      if (anim) anim.destroy();
+      anim = lottie.loadAnimation({
+        container: document.getElementById('player'),
+        renderer: 'svg',
+        loop: true,
+        autoplay: true,
+        path: path
+      });
+      anim.addEventListener('data_ready', function() {
+        document.getElementById('info').textContent =
+          path.split('/').pop() + '  |  ' + anim.totalFrames + ' frames';
+      });
+      anim.addEventListener('data_failed', function() {
+        document.getElementById('info').textContent = 'FAILED: ' + path;
+      });
+    }
+
+    function setStage(s) {
+      currentStage = s;
+      document.querySelectorAll('#stage-btns button').forEach(function(b) {
+        b.className = b.textContent.toLowerCase().replace('아기','baby').replace('청소년','teen').replace('성체','adult') === s ? 'active' : '';
+      });
+      document.querySelectorAll('#stage-btns button').forEach(function(b) {
+        if ((s === 'baby' && b.textContent === '아기') ||
+            (s === 'teen' && b.textContent === '청소년') ||
+            (s === 'adult' && b.textContent === '성체')) b.className = 'active';
+        else b.className = '';
+      });
+      load();
+    }
+
+    function setState(s) {
+      currentState = s;
+      document.querySelectorAll('#state-btns button').forEach(function(b) {
+        b.className = b.textContent === s ? 'active' : '';
+      });
+      load();
+    }
+
+    load();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **렌더링 버그 수정**: `AnimationController.value = 1.0`이 Lottie의 `op=120` (범위 밖) 프레임을 가리켜 투명하게 렌더링되던 문제 수정 → `repeat: true` 자체 루프 재생으로 전환
- **스테이지 매핑 불일치 수정**: Lottie 에셋 teen 범위가 Lv.3~6이었으나 진화 UI(Lv.7~14=청소년) 기준에 맞게 Lv.3~14로 수정
- **Flutter Web 지원**: `HtmlElementView` + lottie-web JS를 사용해 웹에서도 캐릭터 렌더링 가능하도록 추가
- **lottie_preview.html 개선**: 15개 에셋(3단계×5상태) 전환 가능한 인터랙티브 프리뷰 추가

## Test plan

- [ ] iOS/Android 기기에서 캐릭터 카드에 먹찌 캐릭터 정상 표시 확인
- [ ] Lv.7 캐릭터가 teen 에셋(`mukzzi_teen_*`)으로 렌더링되는지 확인
- [ ] `flutter run -d chrome` 웹에서 캐릭터 표시 확인
- [ ] 모든 상태(idle/happy/hungry/starving/sleeping) 전환 시 에셋 정상 로드 확인