### PR TITLE
[codex] Add equipment management screen

### DIFF
--- a/backend/internal/usecase/user_equipment_test.go
+++ b/backend/internal/usecase/user_equipment_test.go
@@ -141,6 +141,20 @@ func TestUserUsecase_EquipItemBySlot(t *testing.T) {
 		assert.Equal(t, int64(502), equipment[0].RewardID)
 	})
 
+	t.Run("빈 문자열 reward ID도 슬롯 해제로 처리한다", func(t *testing.T) {
+		uc, db, userID := setupEquipmentTest(t)
+		createOwnedReward(t, db, userID, 701, domain.EquipmentSlotHead, "CAP")
+
+		rewardID := "701"
+		emptyID := ""
+		require.NoError(t, uc.EquipItem(userID, domain.EquipmentSlotHead, &rewardID))
+		require.NoError(t, uc.EquipItem(userID, domain.EquipmentSlotHead, &emptyID))
+
+		var equipment []domain.CharacterEquipment
+		require.NoError(t, db.Where("user_id = ?", userID).Find(&equipment).Error)
+		require.Empty(t, equipment)
+	})
+
 	t.Run("요청 슬롯과 보상 슬롯이 다르면 거부한다", func(t *testing.T) {
 		uc, db, userID := setupEquipmentTest(t)
 		createOwnedReward(t, db, userID, 601, domain.EquipmentSlotHead, "CAP")

--- a/frontend/lib/src/features/character/domain/models/reward_model.dart
+++ b/frontend/lib/src/features/character/domain/models/reward_model.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 enum EquipmentSlot {
   background('BACKGROUND'),
   back('BACK'),
@@ -17,6 +19,46 @@ enum EquipmentSlot {
       if (slot.value == value) return slot;
     }
     return null;
+  }
+}
+
+extension EquipmentSlotUi on EquipmentSlot {
+  String get label {
+    switch (this) {
+      case EquipmentSlot.background:
+        return '배경';
+      case EquipmentSlot.back:
+        return '등';
+      case EquipmentSlot.body:
+        return '몸';
+      case EquipmentSlot.hand:
+        return '손';
+      case EquipmentSlot.face:
+        return '얼굴';
+      case EquipmentSlot.head:
+        return '머리';
+      case EquipmentSlot.aura:
+        return '오라';
+    }
+  }
+
+  IconData get icon {
+    switch (this) {
+      case EquipmentSlot.background:
+        return Icons.wallpaper_outlined;
+      case EquipmentSlot.back:
+        return Icons.back_hand_outlined;
+      case EquipmentSlot.body:
+        return Icons.accessibility_new;
+      case EquipmentSlot.hand:
+        return Icons.pan_tool_alt_outlined;
+      case EquipmentSlot.face:
+        return Icons.sentiment_satisfied_alt;
+      case EquipmentSlot.head:
+        return Icons.face_6_outlined;
+      case EquipmentSlot.aura:
+        return Icons.auto_awesome;
+    }
   }
 }
 

--- a/frontend/lib/src/features/character/presentation/pages/character_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/character_page.dart
@@ -82,6 +82,15 @@ class CharacterPage extends ConsumerWidget {
                     equippedAccessory: char?.equippedAccessory?.assetUrl,
                     equipment: char?.equipment ?? const {},
                   ),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      onPressed: () => context.push('/character/equipment'),
+                      icon: const Icon(Icons.checkroom_outlined),
+                      label: const Text('장착 관리'),
+                    ),
+                  ),
                   if (isAdmin) ...[
                     const SizedBox(height: 16),
                     SingleChildScrollView(
@@ -166,7 +175,7 @@ class CharacterPage extends ConsumerWidget {
                   _EquipmentItem(
                     label: '배경',
                     value: char?.equippedBackground?.name ?? '기본 배경',
-                    onTap: () => context.push('/character/rewards'),
+                    onTap: () => context.push('/character/equipment'),
                     tokens: tokens,
                   ),
                   Divider(
@@ -174,7 +183,7 @@ class CharacterPage extends ConsumerWidget {
                   _EquipmentItem(
                     label: '악세서리',
                     value: char?.equippedAccessory?.name ?? '없음',
-                    onTap: () => context.push('/character/rewards'),
+                    onTap: () => context.push('/character/equipment'),
                     tokens: tokens,
                   ),
                 ],

--- a/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
@@ -1,0 +1,472 @@
+import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/collection_states.dart';
+import '../../../../core/widgets/gradient_scaffold.dart';
+import '../../../../core/widgets/mukzzi_character.dart';
+import '../../../profile/presentation/providers/user_provider.dart';
+import '../../data/models/character_model.dart';
+import '../../domain/models/reward_model.dart';
+import '../providers/character_provider.dart';
+import '../providers/reward_provider.dart';
+
+class EquipmentManagementPage extends ConsumerStatefulWidget {
+  const EquipmentManagementPage({super.key});
+
+  @override
+  ConsumerState<EquipmentManagementPage> createState() =>
+      _EquipmentManagementPageState();
+}
+
+class _EquipmentManagementPageState
+    extends ConsumerState<EquipmentManagementPage> {
+  EquipmentSlot? _selectedSlot;
+  bool _isSubmitting = false;
+
+  Future<void> _toggleEquipment({
+    required RewardModel reward,
+    required bool isEquipped,
+  }) async {
+    if (_isSubmitting) return;
+
+    final slot = reward.renderConfig?.slot;
+    if (slot == null) return;
+
+    setState(() => _isSubmitting = true);
+    try {
+      final repository = ref.read(characterRepositoryProvider);
+      await repository.equipItem(
+        slot: slot.value,
+        rewardId: isEquipped ? null : reward.id,
+      );
+      _invalidateCharacters();
+
+      if (!mounted) return;
+      if (isEquipped) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('장착 해제되었습니다.'),
+            action: SnackBarAction(
+              label: '되돌리기',
+              onPressed: () => _undoUnequip(slot: slot, rewardId: reward.id),
+            ),
+          ),
+        );
+      }
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(isEquipped ? '해제에 실패했습니다.' : '장착에 실패했습니다.')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  Future<void> _undoUnequip({
+    required EquipmentSlot slot,
+    required String rewardId,
+  }) async {
+    try {
+      await ref.read(characterRepositoryProvider).equipItem(
+            slot: slot.value,
+            rewardId: rewardId,
+          );
+      _invalidateCharacters();
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('되돌리기에 실패했습니다.')),
+      );
+    }
+  }
+
+  void _invalidateCharacters() {
+    ref.invalidate(characterProvider);
+    ref.invalidate(testCharacterProvider);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = Theme.of(context).extension<AppColorTokens>()!;
+    final currentUser = ref.watch(userProvider).user;
+    final isAdmin = kDebugMode || currentUser?.username == 'admin';
+    final AsyncValue<CharacterModel?> characterAsync = isAdmin
+        ? ref.watch(testCharacterProvider)
+        : ref
+            .watch(characterProvider)
+            .whenData<CharacterModel?>((character) => character);
+    final rewardsAsync = ref.watch(rewardListProvider);
+
+    return GradientScaffold(
+      appBar: AppBar(title: const Text('장착 관리')),
+      body: characterAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => CollectionErrorState(onRetry: _invalidateCharacters),
+        data: (character) {
+          if (character == null) {
+            return const CollectionEmptyState(
+              icon: Icons.person_off_outlined,
+              title: '캐릭터를 불러오지 못했어요',
+              subtitle: '캐릭터가 생성된 뒤 장착을 관리할 수 있어요',
+            );
+          }
+
+          return rewardsAsync.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (_, __) => CollectionErrorState(
+              onRetry: () => ref.invalidate(rewardListProvider),
+            ),
+            data: (rewards) {
+              final candidates = rewards.where((reward) {
+                final slot = reward.renderConfig?.slot;
+                if (!reward.acquired || slot == null) return false;
+                return _selectedSlot == null || slot == _selectedSlot;
+              }).toList();
+
+              return Column(
+                children: [
+                  _CharacterPreview(character: character, tokens: tokens),
+                  _SlotSelector(
+                    selectedSlot: _selectedSlot,
+                    equipment: character.equipment,
+                    tokens: tokens,
+                    onSelected: (slot) => setState(() => _selectedSlot = slot),
+                  ),
+                  Expanded(
+                    child: candidates.isEmpty
+                        ? const CollectionEmptyState(
+                            icon: Icons.inventory_2_outlined,
+                            title: '장착할 수 있는 아이템이 없어요',
+                            subtitle: '획득한 장착 아이템이 여기에 표시돼요',
+                          )
+                        : ListView.separated(
+                            padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+                            itemCount: candidates.length,
+                            separatorBuilder: (_, __) =>
+                                const SizedBox(height: 10),
+                            itemBuilder: (context, index) {
+                              final reward = candidates[index];
+                              final slot = reward.renderConfig!.slot;
+                              final isEquipped =
+                                  character.equipment[slot]?.id == reward.id;
+                              return _EquipmentRewardCard(
+                                reward: reward,
+                                slot: slot,
+                                isEquipped: isEquipped,
+                                isSubmitting: _isSubmitting,
+                                tokens: tokens,
+                                onTap: () => _toggleEquipment(
+                                  reward: reward,
+                                  isEquipped: isEquipped,
+                                ),
+                              );
+                            },
+                          ),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CharacterPreview extends StatelessWidget {
+  const _CharacterPreview({
+    required this.character,
+    required this.tokens,
+  });
+
+  final CharacterModel character;
+  final AppColorTokens tokens;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        gradient: tokens.cardHeroGrad,
+        borderRadius: BorderRadius.circular(tokens.rHero),
+      ),
+      child: Column(
+        children: [
+          Text(
+            character.name,
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w700,
+              color: tokens.heroText,
+            ),
+          ),
+          const SizedBox(height: 12),
+          MukzziCharacter(
+            state: character.state,
+            size: 180,
+            showAccessory: character.equippedAccessory != null,
+            equippedAccessory: character.equippedAccessory?.assetUrl,
+            equipment: character.equipment,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SlotSelector extends StatelessWidget {
+  const _SlotSelector({
+    required this.selectedSlot,
+    required this.equipment,
+    required this.tokens,
+    required this.onSelected,
+  });
+
+  final EquipmentSlot? selectedSlot;
+  final Map<EquipmentSlot, RewardModel> equipment;
+  final AppColorTokens tokens;
+  final ValueChanged<EquipmentSlot?> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 48,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        children: [
+          _SlotChip(
+            label: '전체',
+            icon: Icons.apps,
+            selected: selectedSlot == null,
+            equipped: equipment.isNotEmpty,
+            tokens: tokens,
+            onTap: () => onSelected(null),
+          ),
+          ...EquipmentSlot.values.map(
+            (slot) => _SlotChip(
+              label: slot.label,
+              icon: slot.icon,
+              selected: selectedSlot == slot,
+              equipped: equipment.containsKey(slot),
+              tokens: tokens,
+              onTap: () => onSelected(slot),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SlotChip extends StatelessWidget {
+  const _SlotChip({
+    required this.label,
+    required this.icon,
+    required this.selected,
+    required this.equipped,
+    required this.tokens,
+    required this.onTap,
+  });
+
+  final String label;
+  final IconData icon;
+  final bool selected;
+  final bool equipped;
+  final AppColorTokens tokens;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final foreground =
+        selected || equipped ? tokens.primary : tokens.textMuted;
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: ChoiceChip(
+        selected: selected,
+        showCheckmark: false,
+        avatar: Icon(icon, size: 18, color: foreground),
+        label: Text(label),
+        labelStyle: TextStyle(
+          color: selected ? tokens.textPrimary : tokens.textSub,
+          fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+        ),
+        selectedColor: tokens.primaryBg,
+        backgroundColor: tokens.card,
+        side: BorderSide(
+          color: equipped
+              ? tokens.primary.withValues(alpha: selected ? 0.8 : 0.45)
+              : tokens.textMuted.withValues(alpha: 0.18),
+        ),
+        onSelected: (_) => onTap(),
+      ),
+    );
+  }
+}
+
+class _EquipmentRewardCard extends StatelessWidget {
+  const _EquipmentRewardCard({
+    required this.reward,
+    required this.slot,
+    required this.isEquipped,
+    required this.isSubmitting,
+    required this.tokens,
+    required this.onTap,
+  });
+
+  final RewardModel reward;
+  final EquipmentSlot slot;
+  final bool isEquipped;
+  final bool isSubmitting;
+  final AppColorTokens tokens;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: tokens.card,
+      borderRadius: BorderRadius.circular(tokens.rItem),
+      child: InkWell(
+        onTap: isSubmitting ? null : onTap,
+        borderRadius: BorderRadius.circular(tokens.rItem),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: tokens.primaryBg,
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Icon(slot.icon, color: tokens.primary),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        _SlotLabel(label: slot.label, tokens: tokens),
+                        if (isEquipped) ...[
+                          const SizedBox(width: 6),
+                          _EquippedLabel(tokens: tokens),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      reward.name,
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w700,
+                        color: tokens.textPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      reward.description,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(fontSize: 12, color: tokens.textMuted),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              _ActionLabel(
+                label: isEquipped ? '해제' : '장착',
+                isEquipped: isEquipped,
+                tokens: tokens,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SlotLabel extends StatelessWidget {
+  const _SlotLabel({required this.label, required this.tokens});
+
+  final String label;
+  final AppColorTokens tokens;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      label,
+      style: TextStyle(
+        fontSize: 11,
+        fontWeight: FontWeight.w700,
+        color: tokens.primary,
+      ),
+    );
+  }
+}
+
+class _EquippedLabel extends StatelessWidget {
+  const _EquippedLabel({required this.tokens});
+
+  final AppColorTokens tokens;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: tokens.primary.withValues(alpha: 0.16),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        '장착중',
+        style: TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
+          color: tokens.primary,
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionLabel extends StatelessWidget {
+  const _ActionLabel({
+    required this.label,
+    required this.isEquipped,
+    required this.tokens,
+  });
+
+  final String label;
+  final bool isEquipped;
+  final AppColorTokens tokens;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+      decoration: BoxDecoration(
+        color: isEquipped ? tokens.listItemBg : tokens.primaryBg,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w700,
+          color: isEquipped ? tokens.textSub : tokens.primary,
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
@@ -71,7 +71,7 @@ class _EquipmentManagementPageState
     required EquipmentSlot slot,
     required String rewardId,
   }) async {
-    if (_isSubmitting) return;
+    if (!mounted || _isSubmitting) return;
 
     setState(() => _isSubmitting = true);
     try {

--- a/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
@@ -41,9 +41,9 @@ class _EquipmentManagementPageState
         slot: slot.value,
         rewardId: isEquipped ? null : reward.id,
       );
+      if (!mounted) return;
       _invalidateCharacters();
 
-      if (!mounted) return;
       if (isEquipped) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -71,17 +71,23 @@ class _EquipmentManagementPageState
     required EquipmentSlot slot,
     required String rewardId,
   }) async {
+    if (_isSubmitting) return;
+
+    setState(() => _isSubmitting = true);
     try {
-      await ref.read(characterRepositoryProvider).equipItem(
-            slot: slot.value,
-            rewardId: rewardId,
-          );
+      final repository = ref.read(characterRepositoryProvider);
+      await repository.equipItem(slot: slot.value, rewardId: rewardId);
+      if (!mounted) return;
       _invalidateCharacters();
     } catch (_) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('되돌리기에 실패했습니다.')),
       );
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
     }
   }
 

--- a/frontend/lib/src/router/app_router.dart
+++ b/frontend/lib/src/router/app_router.dart
@@ -16,6 +16,7 @@ import '../features/character/presentation/pages/mastery_list_page.dart';
 import '../features/character/presentation/pages/title_list_page.dart';
 import '../features/character/presentation/pages/reward_list_page.dart';
 import '../features/character/presentation/pages/character_collection_page.dart';
+import '../features/character/presentation/pages/equipment_management_page.dart';
 import '../features/profile/presentation/pages/onboarding_page.dart';
 import '../features/profile/presentation/pages/profile_page.dart';
 import '../features/profile/presentation/pages/edit_profile_page.dart';
@@ -189,6 +190,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   path: 'titles',
                   name: 'character-titles',
                   builder: (context, state) => const TitleListPage(),
+                ),
+                GoRoute(
+                  path: 'equipment',
+                  name: 'character-equipment',
+                  builder: (context, state) => const EquipmentManagementPage(),
                 ),
                 GoRoute(
                   path: 'rewards',

--- a/frontend/test/features/character/equipment_management_page_test.dart
+++ b/frontend/test/features/character/equipment_management_page_test.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mukzzi/src/core/network/api_client.dart';
+import 'package:mukzzi/src/core/storage/token_storage.dart';
+import 'package:mukzzi/src/core/theme/app_theme.dart';
+import 'package:mukzzi/src/core/widgets/mukzzi_character.dart';
+import 'package:mukzzi/src/features/character/data/models/character_model.dart';
+import 'package:mukzzi/src/features/character/data/repositories/character_repository.dart';
+import 'package:mukzzi/src/features/character/domain/models/reward_model.dart';
+import 'package:mukzzi/src/features/character/presentation/pages/equipment_management_page.dart';
+import 'package:mukzzi/src/features/character/presentation/providers/character_provider.dart';
+import 'package:mukzzi/src/features/character/presentation/providers/reward_provider.dart';
+import 'package:mukzzi/src/features/profile/data/models/user_model.dart';
+import 'package:mukzzi/src/features/profile/data/repositories/user_repository.dart';
+import 'package:mukzzi/src/features/profile/presentation/providers/user_provider.dart';
+
+class _FakeTokenStorage implements TokenStorage {
+  @override
+  Future<void> delete(String key) async {}
+
+  @override
+  Future<void> deleteAll(List<String> keys) async {}
+
+  @override
+  Future<String?> read(String key) async => null;
+
+  @override
+  Future<void> write(String key, String value) async {}
+}
+
+class _FakeUserRepository extends UserRepository {
+  _FakeUserRepository() : super(ApiClient(_FakeTokenStorage()));
+
+  @override
+  Future<UserModel> getMe() async => _adminUser;
+}
+
+class _FakeCharacterRepository extends CharacterRepository {
+  _FakeCharacterRepository(this.character)
+      : super(ApiClient(_FakeTokenStorage()));
+
+  final CharacterModel character;
+  final equipCalls = <({String slot, String? rewardId})>[];
+
+  @override
+  Future<CharacterModel> getMyCharacter() async => character;
+
+  @override
+  Future<void> equipItem({
+    required String slot,
+    required String? rewardId,
+  }) async {
+    equipCalls.add((slot: slot, rewardId: rewardId));
+  }
+}
+
+final _adminUser = UserModel(
+  id: 'admin-user',
+  username: 'admin',
+  email: 'admin@example.com',
+);
+
+RewardModel _reward({
+  required String id,
+  required String name,
+  required EquipmentSlot slot,
+  bool acquired = true,
+}) {
+  return RewardModel(
+    id: id,
+    rewardType: 'ACCESSORY',
+    code: name,
+    name: name,
+    description: '$name description',
+    assetUrl: 'https://example.com/$id.svg',
+    acquired: acquired,
+    renderConfig: RewardRenderConfig(
+      slot: slot,
+      offsetX: 0,
+      offsetY: 0,
+      scale: 1,
+      rotation: 0,
+      zIndex: 0,
+    ),
+  );
+}
+
+CharacterModel _character(
+    {Map<EquipmentSlot, RewardModel> equipment = const {}}) {
+  return CharacterModel(
+    id: 'character-1',
+    userId: 'user-1',
+    name: '먹찌',
+    state: CharacterState.normal,
+    streakDays: 0,
+    bodyType: 0,
+    muscle: 0,
+    skinTone: 0,
+    expression: 0,
+    nutritionAchievementDays: 0,
+    equipment: equipment,
+  );
+}
+
+Widget _wrap({
+  required _FakeCharacterRepository characterRepository,
+  required List<RewardModel> rewards,
+}) {
+  final userRepository = _FakeUserRepository();
+
+  return ProviderScope(
+    overrides: [
+      userRepositoryProvider.overrideWithValue(userRepository),
+      userProvider.overrideWith(
+        (ref) => UserNotifier(userRepository, initialUser: _adminUser),
+      ),
+      characterRepositoryProvider.overrideWithValue(characterRepository),
+      characterProvider.overrideWith(
+        (ref) => characterRepository.getMyCharacter(),
+      ),
+      rewardListProvider.overrideWith((ref) async => rewards),
+    ],
+    child: MaterialApp(
+      theme: AppTheme.darkTheme,
+      home: const EquipmentManagementPage(),
+    ),
+  );
+}
+
+void main() {
+  group('EquipmentManagementPage', () {
+    testWidgets('전체 탭에는 모든 장착 보상이 보이고 머리 탭에는 HEAD 보상만 보인다', (tester) async {
+      final headReward = _reward(
+        id: '1',
+        name: '머리 왕관',
+        slot: EquipmentSlot.head,
+      );
+      final faceReward = _reward(
+        id: '2',
+        name: '얼굴 안경',
+        slot: EquipmentSlot.face,
+      );
+
+      await tester.pumpWidget(
+        _wrap(
+          characterRepository: _FakeCharacterRepository(_character()),
+          rewards: [headReward, faceReward],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('머리 왕관'), findsOneWidget);
+      expect(find.text('얼굴 안경'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(ChoiceChip, '머리'));
+      await tester.pump();
+
+      expect(find.text('머리 왕관'), findsOneWidget);
+      expect(find.text('얼굴 안경'), findsNothing);
+    });
+
+    testWidgets('빈 슬롯 아이템을 누르면 HEAD 슬롯에 해당 보상을 장착한다', (tester) async {
+      final headReward = _reward(
+        id: '1',
+        name: '머리 왕관',
+        slot: EquipmentSlot.head,
+      );
+      final repository = _FakeCharacterRepository(_character());
+
+      await tester.pumpWidget(
+        _wrap(characterRepository: repository, rewards: [headReward]),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('머리 왕관'));
+      await tester.pump();
+
+      expect(
+        repository.equipCalls,
+        [(slot: 'HEAD', rewardId: '1')],
+      );
+    });
+
+    testWidgets('장착중 아이템을 누르면 해제하고 SnackBar 되돌리기로 재장착한다', (tester) async {
+      final headReward = _reward(
+        id: '1',
+        name: '머리 왕관',
+        slot: EquipmentSlot.head,
+      );
+      final repository = _FakeCharacterRepository(
+        _character(equipment: {EquipmentSlot.head: headReward}),
+      );
+
+      await tester.pumpWidget(
+        _wrap(characterRepository: repository, rewards: [headReward]),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('머리 왕관'));
+      await tester.pump();
+
+      expect(
+        repository.equipCalls,
+        [(slot: 'HEAD', rewardId: null)],
+      );
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(find.text('되돌리기'), findsOneWidget);
+
+      await tester.tap(find.byType(SnackBarAction));
+      await tester.pump();
+
+      expect(
+        repository.equipCalls,
+        [
+          (slot: 'HEAD', rewardId: null),
+          (slot: 'HEAD', rewardId: '1'),
+        ],
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add a dedicated character equipment management screen at `/character/equipment`.
- Add slot filtering, equip/replace, unequip, and SnackBar undo flows using the existing slot equipment API.
- Add equipment slot UI helpers and focused backend/frontend tests for equipment behavior.

## User Impact
- Users can manage equipped character parts from a focused equipment screen instead of only toggling items from the reward list.
- Existing reward-list quick equip/unequip behavior remains available.

## Validation
- `go test ./...` in `backend`
- `flutter analyze` in `frontend`
- `flutter test test/features/character/character_repository_test.dart test/features/character/equipment_management_page_test.dart` in `frontend`

## Notes
- Full `flutter test` still fails on pre-existing unrelated widget test issues: SocialPage `No ProviderScope found`, HomePage provider `UnimplementedError`, and stale `이번주 칼로리` expectation.