### PR TITLE
fix: 장비 장착/해제 시 레거시 컬럼 동기화 및 홈 쇼케이스 로딩 안정성 개선

### DIFF
--- a/backend/internal/usecase/user.go
+++ b/backend/internal/usecase/user.go
@@ -742,8 +742,14 @@ func (u *userUsecase) EquipItem(userID int64, slot domain.EquipmentSlot, rewardI
 	}
 
 	if rewardIDStr == nil || *rewardIDStr == "" {
-		if err := u.db.Where("character_id = ? AND slot = ?", char.ID, slot).
-			Delete(&domain.CharacterEquipment{}).Error; err != nil {
+		err := u.db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Where("character_id = ? AND slot = ?", char.ID, slot).
+				Delete(&domain.CharacterEquipment{}).Error; err != nil {
+				return err
+			}
+			return syncLegacyEquipmentColumn(tx, char.ID, slot, nil)
+		})
+		if err != nil {
 			return err
 		}
 		u.invalidateCharacterCaches(userID)
@@ -779,33 +785,51 @@ func (u *userUsecase) EquipItem(userID int64, slot domain.EquipmentSlot, rewardI
 		return ErrRewardNotOwned
 	}
 
-	var existing domain.CharacterEquipment
-	err = u.db.Where("character_id = ? AND slot = ?", char.ID, slot).First(&existing).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		equipment := domain.CharacterEquipment{
-			CharacterID: char.ID,
-			UserID:      userID,
-			Slot:        slot,
-			RewardID:    rewardID,
-			EquippedAt:  time.Now(),
+	err = u.db.Transaction(func(tx *gorm.DB) error {
+		var existing domain.CharacterEquipment
+		err = tx.Where("character_id = ? AND slot = ?", char.ID, slot).First(&existing).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			equipment := domain.CharacterEquipment{
+				CharacterID: char.ID,
+				UserID:      userID,
+				Slot:        slot,
+				RewardID:    rewardID,
+				EquippedAt:  time.Now(),
+			}
+			if err := tx.Create(&equipment).Error; err != nil {
+				return err
+			}
+			return syncLegacyEquipmentColumn(tx, char.ID, slot, &rewardID)
 		}
-		if err := u.db.Create(&equipment).Error; err != nil {
+		if err != nil {
 			return err
 		}
-		u.invalidateCharacterCaches(userID)
-		return nil
-	}
-	if err != nil {
-		return err
-	}
 
-	existing.RewardID = rewardID
-	existing.EquippedAt = time.Now()
-	if err := u.db.Save(&existing).Error; err != nil {
+		existing.RewardID = rewardID
+		existing.EquippedAt = time.Now()
+		if err := tx.Save(&existing).Error; err != nil {
+			return err
+		}
+		return syncLegacyEquipmentColumn(tx, char.ID, slot, &rewardID)
+	})
+	if err != nil {
 		return err
 	}
 	u.invalidateCharacterCaches(userID)
 	return nil
+}
+
+func syncLegacyEquipmentColumn(tx *gorm.DB, charID int64, slot domain.EquipmentSlot, rewardID *int64) error {
+	switch slot {
+	case domain.EquipmentSlotHead:
+		return tx.Model(&domain.Character{}).Where("id = ?", charID).
+			Update("equipped_accessory_id", rewardID).Error
+	case domain.EquipmentSlotBackground:
+		return tx.Model(&domain.Character{}).Where("id = ?", charID).
+			Update("equipped_background_id", rewardID).Error
+	default:
+		return nil
+	}
 }
 
 func isValidEquipmentSlot(slot domain.EquipmentSlot) bool {

--- a/backend/internal/usecase/user_equipment_test.go
+++ b/backend/internal/usecase/user_equipment_test.go
@@ -155,6 +155,44 @@ func TestUserUsecase_EquipItemBySlot(t *testing.T) {
 		require.Empty(t, equipment)
 	})
 
+	t.Run("HEAD 슬롯 장착과 해제는 레거시 액세서리 컬럼도 동기화한다", func(t *testing.T) {
+		uc, db, userID := setupEquipmentTest(t)
+		createOwnedReward(t, db, userID, 801, domain.EquipmentSlotHead, "CAP")
+
+		rewardID := "801"
+		require.NoError(t, uc.EquipItem(userID, domain.EquipmentSlotHead, &rewardID))
+
+		var equipped domain.Character
+		require.NoError(t, db.Where("user_id = ?", userID).First(&equipped).Error)
+		require.NotNil(t, equipped.EquippedAccessoryID)
+		assert.Equal(t, int64(801), *equipped.EquippedAccessoryID)
+
+		require.NoError(t, uc.EquipItem(userID, domain.EquipmentSlotHead, nil))
+
+		var unequipped domain.Character
+		require.NoError(t, db.Where("user_id = ?", userID).First(&unequipped).Error)
+		assert.Nil(t, unequipped.EquippedAccessoryID)
+	})
+
+	t.Run("BACKGROUND 슬롯 장착과 해제는 레거시 배경 컬럼도 동기화한다", func(t *testing.T) {
+		uc, db, userID := setupEquipmentTest(t)
+		createOwnedReward(t, db, userID, 901, domain.EquipmentSlotBackground, "BG")
+
+		rewardID := "901"
+		require.NoError(t, uc.EquipItem(userID, domain.EquipmentSlotBackground, &rewardID))
+
+		var equipped domain.Character
+		require.NoError(t, db.Where("user_id = ?", userID).First(&equipped).Error)
+		require.NotNil(t, equipped.EquippedBackgroundID)
+		assert.Equal(t, int64(901), *equipped.EquippedBackgroundID)
+
+		require.NoError(t, uc.EquipItem(userID, domain.EquipmentSlotBackground, nil))
+
+		var unequipped domain.Character
+		require.NoError(t, db.Where("user_id = ?", userID).First(&unequipped).Error)
+		assert.Nil(t, unequipped.EquippedBackgroundID)
+	})
+
 	t.Run("요청 슬롯과 보상 슬롯이 다르면 거부한다", func(t *testing.T) {
 		uc, db, userID := setupEquipmentTest(t)
 		createOwnedReward(t, db, userID, 601, domain.EquipmentSlotHead, "CAP")

--- a/frontend/lib/src/features/home/presentation/pages/home_page.dart
+++ b/frontend/lib/src/features/home/presentation/pages/home_page.dart
@@ -1,5 +1,6 @@
 import "package:showcaseview/showcaseview.dart";
 import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -27,6 +28,18 @@ import 'package:mukzzi/src/features/meal_record/data/models/meal_model.dart';
 import 'package:mukzzi/src/features/meal_record/presentation/providers/meal_provider.dart';
 import 'package:mukzzi/src/features/quest/domain/entities/quest.dart';
 import 'package:mukzzi/src/features/quest/presentation/providers/quest_provider.dart';
+
+@visibleForTesting
+bool isShowcaseTargetReady(GlobalKey key) {
+  final context = key.currentContext;
+  if (context == null) return false;
+
+  final renderObject = context.findRenderObject();
+  return renderObject is RenderBox &&
+      renderObject.attached &&
+      renderObject.hasSize &&
+      !renderObject.size.isEmpty;
+}
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
@@ -62,10 +75,31 @@ class _HomePageState extends ConsumerState<HomePage> {
 
     if (hasTutorialQuest) {
       _tutorialStarted = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        ShowcaseView.get().startShowCase([_feedMukzziKey]);
-      });
+      _startFeedMukzziShowcaseWhenReady();
     }
+  }
+
+  void _startFeedMukzziShowcaseWhenReady({int attempt = 0}) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Future.delayed(const Duration(milliseconds: 400), () {
+        if (!mounted) return;
+
+        if (!isShowcaseTargetReady(_feedMukzziKey)) {
+          if (attempt < 3) {
+            _startFeedMukzziShowcaseWhenReady(attempt: attempt + 1);
+          } else {
+            _tutorialStarted = false;
+          }
+          return;
+        }
+
+        try {
+          ShowcaseView.get().startShowCase([_feedMukzziKey]);
+        } catch (_) {
+          _tutorialStarted = false;
+        }
+      });
+    });
   }
 
   @override

--- a/frontend/test/features/home/showcase_target_test.dart
+++ b/frontend/test/features/home/showcase_target_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mukzzi/src/features/home/presentation/pages/home_page.dart';
+
+void main() {
+  testWidgets('쇼케이스 대상이 아직 트리에 없으면 준비되지 않은 상태로 본다', (tester) async {
+    final key = GlobalKey();
+
+    expect(isShowcaseTargetReady(key), isFalse);
+  });
+
+  testWidgets('쇼케이스 대상이 레이아웃된 뒤에만 준비된 상태로 본다', (tester) async {
+    final key = GlobalKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(key: key, width: 80, height: 40),
+        ),
+      ),
+    );
+
+    expect(isShowcaseTargetReady(key), isTrue);
+  });
+}


### PR DESCRIPTION
## 목적
- 백엔드 장비 장착 및 해제(EquipItem) 시 신규 구조 테이블 외에 기존 레거시 장비 컬럼(`equipped_accessory_id`, `equipped_background_id`)과의 동기화 누락을 수정하고 트랜잭션을 적용합니다.
- 프론트엔드 홈 쇼케이스 시작 과정에서 타겟 위젯이 화면상 레이아웃 완료 및 렌더 박스(attached, hasSize, hasNonEmptySize)가 준비되었는지를 검증한 뒤 작동하도록 처리하여 비정상 예외 발생 및 미작동 현상을 방지합니다.

## 변경 사항
### Backend
- `backend/internal/usecase/user.go`
  - `EquipItem` 로직에 트랜잭션을 적용하고, 장착/해제 결과에 맞춰 레거시 컬럼(`equipped_accessory_id`, `equipped_background_id`)을 수정하는 `syncLegacyEquipmentColumn` 함수 추가.
- `backend/internal/usecase/user_equipment_test.go`
  - HEAD 슬롯 및 BACKGROUND 슬롯의 장착/해제와 레거시 컬럼 간의 연동을 확인하는 테스트 유닛 케이스 추가.

### Frontend
- `frontend/lib/src/features/home/presentation/pages/home_page.dart`
  - 타겟 GlobalKey의 렌더 객체 준비 여부를 판별하는 `isShowcaseTargetReady` 헬퍼 함수 추가.
  - Showcase를 비동기 레이아웃 준비 완료 후에 시도하도록 지연 처리 및 최대 3회 재시도 흐름 구축.
- `frontend/test/features/home/showcase_target_test.dart`
  - 타겟 준비 판별 헬퍼 함수에 대한 위젯 테스트 코드 추가.
