### PR TITLE
fix: 웹 환경에서 SSE 수신 시 MessageEvent 캐스팅 에러 수정

### DIFF
--- a/frontend/lib/src/features/notification/data/repositories/sse/sse_client_web.dart
+++ b/frontend/lib/src/features/notification/data/repositories/sse/sse_client_web.dart
@@ -27,16 +27,15 @@ class SseClientWeb implements SseClient {
       });
 
       eventSource.addEventListener('notification', (event) {
-        final html.MessageEvent msgEvent = event as html.MessageEvent;
-        final String data = msgEvent.data.toString();
-        
         try {
+          final dynamic msgEvent = event;
+          final String data = msgEvent.data.toString();
           final json = jsonDecode(data) as Map<String, dynamic>;
           if (!controller.isClosed) {
             controller.add(NotificationModel.fromJson(json));
           }
         } catch (e) {
-          debugPrint('[$_now][SseClientWeb] 파싱 에러: $e');
+          debugPrint('[$_now][SseClientWeb] 에러 발생 (캐스팅/파싱): $e');
         }
       });
 


### PR DESCRIPTION
## 목적
- 웹 환경에서 SSE(Server-Sent Events)를 구독하고 이벤트를 수신할 때, 브라우저의 `MessageEvent` 객체가 Dart의 `html.MessageEvent`로 안전하게 다운캐스팅되지 않아 런타임에 `TypeError`가 발생하던 문제를 해결합니다.

## 변경 사항
### Frontend
- `frontend/lib/src/features/notification/data/repositories/sse/sse_client_web.dart`
  - 이벤트 리스너 콜백에서 `as html.MessageEvent` 캐스팅을 제외하고 `dynamic` 타입을 사용하여 속성에 우회 접근하도록 리팩토링.
  - 형변환 및 파싱 관련 전체 로직을 `try-catch` 블록 내부로 감싸 예외가 외부로 전파(Uncaught Error)되지 않도록 안정성 확보.
