### PR TITLE
feat: 캐릭터 프리뷰 시멀리스 통일

### DIFF
--- a/frontend/lib/src/core/widgets/mukzzi_character.dart
+++ b/frontend/lib/src/core/widgets/mukzzi_character.dart
@@ -412,13 +412,14 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
       fit: BoxFit.contain,
     );
 
-    // 중간 강도 가장자리 페이드: 중심 ~60%는 솔리드, 가장자리로 갈수록 투명
+    // 중간 강도 가장자리 페이드: 중심 ~34%는 솔리드, 변 중앙(0.5×변)에서 완전 투명.
+    // radius 0.5 = 변 중앙에서 alpha 0 도달 — 사각 경계가 남지 않는 최대 radius.
     if (widget.backgroundEdgeFade && config.slot == EquipmentSlot.background) {
       layer = ShaderMask(
         shaderCallback: (bounds) => const RadialGradient(
-          radius: 0.75,
+          radius: 0.5,
           colors: [Colors.black, Colors.black, Colors.transparent],
-          stops: [0.0, 0.6, 1.0],
+          stops: [0.0, 0.68, 1.0],
         ).createShader(bounds),
         blendMode: BlendMode.dstIn,
         child: layer,

--- a/frontend/lib/src/core/widgets/mukzzi_character.dart
+++ b/frontend/lib/src/core/widgets/mukzzi_character.dart
@@ -121,6 +121,7 @@ class MukzziCharacter extends StatelessWidget {
   final bool showAccessory;
   final String? equippedAccessory;
   final Map<EquipmentSlot, RewardModel> equipment;
+  final bool backgroundEdgeFade;
 
   const MukzziCharacter({
     super.key,
@@ -129,6 +130,7 @@ class MukzziCharacter extends StatelessWidget {
     this.showAccessory = false,
     this.equippedAccessory,
     this.equipment = const {},
+    this.backgroundEdgeFade = false,
   }) : assert(size >= 60,
             'MukzziCharacter: size < 60 renders detail-loss. Use at least 80 for best results.');
 
@@ -160,6 +162,7 @@ class MukzziCharacter extends StatelessWidget {
       showAccessory: showAccessory,
       equippedAccessory: equippedAccessory,
       equipment: equipment,
+      backgroundEdgeFade: backgroundEdgeFade,
     );
   }
 }
@@ -170,6 +173,7 @@ class _SvgLayeredCharacter extends StatefulWidget {
   final bool showAccessory;
   final String? equippedAccessory;
   final Map<EquipmentSlot, RewardModel> equipment;
+  final bool backgroundEdgeFade;
 
   const _SvgLayeredCharacter({
     required this.state,
@@ -177,6 +181,7 @@ class _SvgLayeredCharacter extends StatefulWidget {
     required this.showAccessory,
     this.equippedAccessory,
     required this.equipment,
+    required this.backgroundEdgeFade,
   });
 
   @override
@@ -399,21 +404,34 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
     final path = 'assets/svg/mukzzi2_${reward.assetUrl}.svg';
     final layerSize = widget.size * config.scale;
 
+    Widget layer = SvgPicture.asset(
+      path,
+      key: ValueKey(path),
+      width: layerSize,
+      height: layerSize,
+      fit: BoxFit.contain,
+    );
+
+    // 중간 강도 가장자리 페이드: 중심 ~60%는 솔리드, 가장자리로 갈수록 투명
+    if (widget.backgroundEdgeFade && config.slot == EquipmentSlot.background) {
+      layer = ShaderMask(
+        shaderCallback: (bounds) => const RadialGradient(
+          radius: 0.75,
+          colors: [Colors.black, Colors.black, Colors.transparent],
+          stops: [0.0, 0.6, 1.0],
+        ).createShader(bounds),
+        blendMode: BlendMode.dstIn,
+        child: layer,
+      );
+    }
+
     return Positioned.fill(
       child: Transform.translate(
         offset:
             Offset(widget.size * config.offsetX, widget.size * config.offsetY),
         child: Transform.rotate(
           angle: config.rotation * math.pi / 180,
-          child: Center(
-            child: SvgPicture.asset(
-              path,
-              key: ValueKey(path),
-              width: layerSize,
-              height: layerSize,
-              fit: BoxFit.contain,
-            ),
-          ),
+          child: Center(child: layer),
         ),
       ),
     );

--- a/frontend/lib/src/features/character/presentation/pages/character_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/character_page.dart
@@ -61,54 +61,50 @@ class CharacterPage extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 12),
-            // 캐릭터 히어로 카드
-            BentoCard(
-              showPaperTexture: true,
-              borderRadius: BorderRadius.circular(tokens.rHero),
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 24),
-              child: Column(
-                children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      _nutritionBadge('$nutritionDays일', tokens),
-                      _statePill(state, tokens),
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-                  MukzziCharacter(
-                    state: state,
-                    size: 200,
-                    showAccessory: char?.equippedAccessory != null,
-                    equippedAccessory: char?.equippedAccessory?.assetUrl,
-                    equipment: char?.equipment ?? const {},
-                  ),
-                  if (isAdmin) ...[
-                    const SizedBox(height: 16),
-                    SingleChildScrollView(
-                      scrollDirection: Axis.horizontal,
-                      child: Row(
-                        children: CharacterState.values.map((s) {
-                          return Padding(
-                            padding: const EdgeInsets.only(right: 8),
-                            child: ActionChip(
-                              label: Text(s.label,
-                                  style: const TextStyle(fontSize: 10)),
-                              onPressed: () => ref
-                                  .read(testCharacterProvider.notifier)
-                                  .updateState(s),
-                              backgroundColor: state == s
-                                  ? tokens.primary.withValues(alpha: 0.2)
-                                  : null,
-                            ),
-                          );
-                        }).toList(),
-                      ),
-                    ),
-                  ],
-                ],
+            // 캐릭터 히어로 — 시멀리스 (카드 없음)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                _nutritionBadge('$nutritionDays일', tokens),
+                _statePill(state, tokens),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Center(
+              child: MukzziCharacter(
+                state: state,
+                size: (MediaQuery.of(context).size.width * 0.45)
+                    .clamp(150.0, 200.0)
+                    .toDouble(),
+                showAccessory: char?.equippedAccessory != null,
+                equippedAccessory: char?.equippedAccessory?.assetUrl,
+                equipment: char?.equipment ?? const {},
+                backgroundEdgeFade: true,
               ),
             ),
+            if (isAdmin) ...[
+              const SizedBox(height: 16),
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: CharacterState.values.map((s) {
+                    return Padding(
+                      padding: const EdgeInsets.only(right: 8),
+                      child: ActionChip(
+                        label: Text(s.label,
+                            style: const TextStyle(fontSize: 10)),
+                        onPressed: () => ref
+                            .read(testCharacterProvider.notifier)
+                            .updateState(s),
+                        backgroundColor: state == s
+                            ? tokens.primary.withValues(alpha: 0.2)
+                            : null,
+                      ),
+                    );
+                  }).toList(),
+                ),
+              ),
+            ],
             const SizedBox(height: 24),
 
             // 영양 달성
@@ -278,7 +274,7 @@ class CharacterPage extends ConsumerWidget {
           style: GoogleFonts.poppins(
               fontSize: 12,
               fontWeight: FontWeight.w700,
-              color: tokens.heroText),
+              color: tokens.textPrimary),
         ),
       );
 

--- a/frontend/lib/src/features/character/presentation/pages/character_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/character_page.dart
@@ -15,6 +15,11 @@ import '../providers/title_provider.dart';
 class CharacterPage extends ConsumerWidget {
   const CharacterPage({super.key});
 
+  // 화면폭 대비 캐릭터 크기 비율. clamp와 함께 333~444px 폭 구간에서만 비례 동작.
+  static const double _widthRatio = 0.45;
+  static const double _minCharSize = 150;
+  static const double _maxCharSize = 200;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tokens = Theme.of(context).extension<AppColorTokens>()!;
@@ -73,8 +78,8 @@ class CharacterPage extends ConsumerWidget {
             Center(
               child: MukzziCharacter(
                 state: state,
-                size: (MediaQuery.of(context).size.width * 0.45)
-                    .clamp(150.0, 200.0)
+                size: (MediaQuery.sizeOf(context).width * _widthRatio)
+                    .clamp(_minCharSize, _maxCharSize)
                     .toDouble(),
                 showAccessory: char?.equippedAccessory != null,
                 equippedAccessory: char?.equippedAccessory?.assetUrl,

--- a/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
@@ -335,71 +335,88 @@ class _EquipmentManagementPageState
           return _selectedSlot == null || slot == _selectedSlot;
         }).toList();
 
-        return Column(
-          children: [
-            _CharacterPreview(character: character, tokens: tokens),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  ChoiceChip(
-                    label: const Text('획득한 아이템만'),
-                    selected: _showAcquiredOnly,
-                    onSelected: (val) => setState(() => _showAcquiredOnly = val),
-                  ),
-                  Text('최신순', style: TextStyle(color: tokens.textMuted, fontSize: 12)),
-                ],
-              ),
-            ),
-            _SlotSelector(
-              selectedSlot: _selectedSlot,
-              equipment: character.equipment,
-              tokens: tokens,
-              scrollController: _slotScrollController,
-              onSelected: (slot) => setState(() => _selectedSlot = slot),
-            ),
-            Expanded(
-              child: candidates.isEmpty
-                  ? const CollectionEmptyState(
-                      icon: Icons.inventory_2_outlined,
-                      title: '장착할 수 있는 아이템이 없어요',
-                      subtitle: '획득한 장착 아이템이 여기에 표시돼요',
-                    )
-                  : Center(
-                      child: SizedBox(
-                        width: 480,
-                        child: GridView.builder(
-                          padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
-                          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                            crossAxisCount: 2,
-                            crossAxisSpacing: 10,
-                            mainAxisSpacing: 10,
-                            childAspectRatio: 1.22,
-                          ),
-                          itemCount: candidates.length,
-                          itemBuilder: (context, index) {
-                            final reward = candidates[index];
-                            final slot = reward.renderConfig!.slot;
-                            final isEquipped =
-                                character.equipment[slot]?.id == reward.id;
-                            return _EquipmentRewardCard(
-                              reward: reward,
-                              slot: slot,
-                              isEquipped: isEquipped,
-                              isSubmitting: _isSubmitting,
-                              tokens: tokens,
-                              onTap: () => _toggleEquipment(
-                                reward: reward,
-                                isEquipped: isEquipped,
-                              ),
-                            );
-                          },
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            return Column(
+              children: [
+                _CharacterPreview(
+                  character: character,
+                  availableHeight: constraints.maxHeight,
+                ),
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      ChoiceChip(
+                        label: const Text('획득한 아이템만'),
+                        selected: _showAcquiredOnly,
+                        onSelected: (val) =>
+                            setState(() => _showAcquiredOnly = val),
+                      ),
+                      Text(
+                        '최신순',
+                        style: TextStyle(
+                          color: tokens.textMuted,
+                          fontSize: 12,
                         ),
                       ),
-                    ),
-            ),
-          ],
+                    ],
+                  ),
+                ),
+                _SlotSelector(
+                  selectedSlot: _selectedSlot,
+                  equipment: character.equipment,
+                  tokens: tokens,
+                  scrollController: _slotScrollController,
+                  onSelected: (slot) => setState(() => _selectedSlot = slot),
+                ),
+                Expanded(
+                  child: candidates.isEmpty
+                      ? const CollectionEmptyState(
+                          icon: Icons.inventory_2_outlined,
+                          title: '장착할 수 있는 아이템이 없어요',
+                          subtitle: '획득한 장착 아이템이 여기에 표시돼요',
+                        )
+                      : Center(
+                          child: SizedBox(
+                            width: 480,
+                            child: GridView.builder(
+                              padding:
+                                  const EdgeInsets.fromLTRB(16, 8, 16, 24),
+                              gridDelegate:
+                                  const SliverGridDelegateWithFixedCrossAxisCount(
+                                crossAxisCount: 2,
+                                crossAxisSpacing: 10,
+                                mainAxisSpacing: 10,
+                                childAspectRatio: 1.22,
+                              ),
+                              itemCount: candidates.length,
+                              itemBuilder: (context, index) {
+                                final reward = candidates[index];
+                                final slot = reward.renderConfig!.slot;
+                                final isEquipped =
+                                    character.equipment[slot]?.id == reward.id;
+                                return _EquipmentRewardCard(
+                                  reward: reward,
+                                  slot: slot,
+                                  isEquipped: isEquipped,
+                                  isSubmitting: _isSubmitting,
+                                  tokens: tokens,
+                                  onTap: () => _toggleEquipment(
+                                    reward: reward,
+                                    isEquipped: isEquipped,
+                                  ),
+                                );
+                              },
+                            ),
+                          ),
+                        ),
+                ),
+              ],
+            );
+          },
         );
       },
     );
@@ -409,50 +426,32 @@ class _EquipmentManagementPageState
 class _CharacterPreview extends StatelessWidget {
   const _CharacterPreview({
     required this.character,
-    required this.tokens,
+    required this.availableHeight,
   });
 
   final CharacterModel character;
-  final AppColorTokens tokens;
+  final double availableHeight;
+
+  // 이 미만이면 MukzziCharacter 권장 최소 80px 확보 불가
+  static const double _minVisibleHeight = 380;
 
   @override
   Widget build(BuildContext context) {
-    final screenHeight = MediaQuery.of(context).size.height;
-    if (screenHeight < 450) {
+    if (availableHeight < _minVisibleHeight) {
       return const SizedBox.shrink();
     }
 
-    final double charSize = screenHeight < 680 ? 90 : 130;
-    final double verticalPadding = screenHeight < 680 ? 6 : 8;
-    final double spacing = screenHeight < 680 ? 4 : 6;
+    final charSize = (availableHeight * 0.18).clamp(80.0, 130.0).toDouble();
 
-    return Container(
-      width: double.infinity,
-      margin: const EdgeInsets.fromLTRB(16, 6, 16, 4),
-      padding: EdgeInsets.symmetric(horizontal: 20, vertical: verticalPadding),
-      decoration: BoxDecoration(
-        gradient: tokens.cardHeroGrad,
-        borderRadius: BorderRadius.circular(tokens.rHero),
-      ),
-      child: Column(
-        children: [
-          Text(
-            character.name,
-            style: TextStyle(
-              fontSize: screenHeight < 680 ? 15 : 18,
-              fontWeight: FontWeight.w700,
-              color: tokens.heroText,
-            ),
-          ),
-          SizedBox(height: spacing),
-          MukzziCharacter(
-            state: character.state,
-            size: charSize,
-            showAccessory: character.equippedAccessory != null,
-            equippedAccessory: character.equippedAccessory?.assetUrl,
-            equipment: character.equipment,
-          ),
-        ],
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: MukzziCharacter(
+        state: character.state,
+        size: charSize,
+        showAccessory: character.equippedAccessory != null,
+        equippedAccessory: character.equippedAccessory?.assetUrl,
+        equipment: character.equipment,
+        backgroundEdgeFade: true,
       ),
     );
   }

--- a/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
@@ -432,8 +432,13 @@ class _CharacterPreview extends StatelessWidget {
   final CharacterModel character;
   final double availableHeight;
 
-  // 이 미만이면 MukzziCharacter 권장 최소 80px 확보 불가
+  // 이 미만이면 프리뷰(최소 80px)가 칩/슬롯 셀렉터/그리드에 필요한 공간을 잠식하는 지점
   static const double _minVisibleHeight = 380;
+
+  // 가용 높이 대비 프리뷰 비율. clamp(80~130)와 함께 444~722px 구간에서만 비례 동작.
+  static const double _heightRatio = 0.18;
+  static const double _minCharSize = 80;
+  static const double _maxCharSize = 130;
 
   @override
   Widget build(BuildContext context) {
@@ -441,7 +446,9 @@ class _CharacterPreview extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    final charSize = (availableHeight * 0.18).clamp(80.0, 130.0).toDouble();
+    final charSize = (availableHeight * _heightRatio)
+        .clamp(_minCharSize, _maxCharSize)
+        .toDouble();
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),

--- a/frontend/test/core/widgets/mukzzi_character_test.dart
+++ b/frontend/test/core/widgets/mukzzi_character_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mukzzi/src/core/widgets/mukzzi_character.dart';
+import 'package:mukzzi/src/features/character/domain/models/reward_model.dart';
+
+RewardModel _backgroundReward() {
+  return const RewardModel(
+    id: 'bg-1',
+    rewardType: 'ACCESSORY',
+    code: 'background_kitchen',
+    name: '주방 배경',
+    description: '주방 배경 아이템',
+    assetUrl: 'background_kitchen',
+    acquired: true,
+    renderConfig: RewardRenderConfig(
+      slot: EquipmentSlot.background,
+      offsetX: 0,
+      offsetY: 0,
+      scale: 1,
+      rotation: 0,
+      zIndex: -10,
+    ),
+  );
+}
+
+Future<void> _pumpCharacter(
+  WidgetTester tester, {
+  required Map<EquipmentSlot, RewardModel> equipment,
+  required bool backgroundEdgeFade,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: MukzziCharacter(
+            equipment: equipment,
+            backgroundEdgeFade: backgroundEdgeFade,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('MukzziCharacter backgroundEdgeFade', () {
+    testWidgets('페이드 활성 + 배경 장착 시 배경 레이어에 ShaderMask를 적용한다',
+        (tester) async {
+      await _pumpCharacter(
+        tester,
+        equipment: {EquipmentSlot.background: _backgroundReward()},
+        backgroundEdgeFade: true,
+      );
+
+      expect(find.byType(ShaderMask), findsOneWidget);
+    });
+
+    testWidgets('페이드 활성이어도 배경 미장착이면 ShaderMask가 없다', (tester) async {
+      await _pumpCharacter(
+        tester,
+        equipment: const {},
+        backgroundEdgeFade: true,
+      );
+
+      expect(find.byType(ShaderMask), findsNothing);
+    });
+
+    testWidgets('기본값(false)이면 배경을 장착해도 ShaderMask가 없다', (tester) async {
+      await _pumpCharacter(
+        tester,
+        equipment: {EquipmentSlot.background: _backgroundReward()},
+        backgroundEdgeFade: false,
+      );
+
+      expect(find.byType(ShaderMask), findsNothing);
+    });
+  });
+}

--- a/frontend/test/features/character/character_page_test.dart
+++ b/frontend/test/features/character/character_page_test.dart
@@ -70,6 +70,9 @@ CharacterModel _character() {
   );
 }
 
+// 주의: flutter test에서는 kDebugMode=true → isAdmin 경로로 testCharacterProvider를 본다.
+// TestCharacterNotifier가 내부에서 characterProvider에 위임하므로 characterProvider
+// override만으로 동작한다. 위임이 사라지면 이 테스트는 불투명하게 실패한다.
 Widget _wrap(_FakeCharacterRepository characterRepository) {
   final userRepository = _FakeUserRepository();
 
@@ -112,9 +115,14 @@ void main() {
       expect(character.size, 180.0);
       expect(character.backgroundEdgeFade, isTrue);
 
-      // 히어로 카드 제거 — 남은 BentoCard는 섹션 카드 3개뿐
-      // (영양 달성 / 장착 중 / 도감)
-      expect(find.byType(BentoCard), findsNWidgets(3));
+      // 히어로 카드 제거 — 캐릭터가 BentoCard 안에 있지 않음
+      expect(
+        find.ancestor(
+          of: find.byType(MukzziCharacter),
+          matching: find.byType(BentoCard),
+        ),
+        findsNothing,
+      );
     });
 
     testWidgets('넓은 화면에서는 캐릭터 크기가 200px 상한으로 고정된다', (tester) async {

--- a/frontend/test/features/character/character_page_test.dart
+++ b/frontend/test/features/character/character_page_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mukzzi/src/core/network/api_client.dart';
+import 'package:mukzzi/src/core/storage/token_storage.dart';
+import 'package:mukzzi/src/core/theme/app_theme.dart';
+import 'package:mukzzi/src/core/widgets/bento_card.dart';
+import 'package:mukzzi/src/core/widgets/mukzzi_character.dart';
+import 'package:mukzzi/src/features/character/data/models/character_model.dart';
+import 'package:mukzzi/src/features/character/data/repositories/character_repository.dart';
+import 'package:mukzzi/src/features/character/domain/models/title_model.dart';
+import 'package:mukzzi/src/features/character/presentation/pages/character_page.dart';
+import 'package:mukzzi/src/features/character/presentation/providers/character_provider.dart';
+import 'package:mukzzi/src/features/character/presentation/providers/title_provider.dart';
+import 'package:mukzzi/src/features/profile/data/models/user_model.dart';
+import 'package:mukzzi/src/features/profile/data/repositories/user_repository.dart';
+import 'package:mukzzi/src/features/profile/presentation/providers/user_provider.dart';
+
+class _FakeTokenStorage implements TokenStorage {
+  @override
+  Future<void> delete(String key) async {}
+
+  @override
+  Future<void> deleteAll(List<String> keys) async {}
+
+  @override
+  Future<String?> read(String key) async => null;
+
+  @override
+  Future<void> write(String key, String value) async {}
+}
+
+class _FakeUserRepository extends UserRepository {
+  _FakeUserRepository() : super(ApiClient(_FakeTokenStorage()));
+
+  @override
+  Future<UserModel> getMe() async => _user;
+}
+
+class _FakeCharacterRepository extends CharacterRepository {
+  _FakeCharacterRepository(this.character)
+      : super(ApiClient(_FakeTokenStorage()));
+
+  final CharacterModel character;
+
+  @override
+  Future<CharacterModel> getMyCharacter() async => character;
+}
+
+final _user = UserModel(
+  id: 'user-1',
+  username: 'tester',
+  email: 'tester@example.com',
+);
+
+CharacterModel _character() {
+  return const CharacterModel(
+    id: 'character-1',
+    userId: 'user-1',
+    name: '먹찌',
+    state: CharacterState.normal,
+    streakDays: 0,
+    bodyType: 0,
+    muscle: 0,
+    skinTone: 0,
+    expression: 0,
+    nutritionAchievementDays: 0,
+    equipment: {},
+  );
+}
+
+Widget _wrap(_FakeCharacterRepository characterRepository) {
+  final userRepository = _FakeUserRepository();
+
+  return ProviderScope(
+    overrides: [
+      userRepositoryProvider.overrideWithValue(userRepository),
+      userProvider.overrideWith(
+        (ref) => UserNotifier(userRepository, initialUser: _user),
+      ),
+      characterRepositoryProvider.overrideWithValue(characterRepository),
+      characterProvider.overrideWith(
+        (ref) => characterRepository.getMyCharacter(),
+      ),
+      titleListProvider.overrideWith((ref) async => <TitleModel>[]),
+    ],
+    child: MaterialApp(
+      theme: AppTheme.darkTheme,
+      home: const CharacterPage(),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('CharacterPage', () {
+    testWidgets('히어로 카드 없이 캐릭터가 화면폭 비례 크기로 표시된다', (tester) async {
+      tester.view.physicalSize = const Size(400, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(_wrap(_FakeCharacterRepository(_character())));
+      await tester.pump();
+
+      final character =
+          tester.widget<MukzziCharacter>(find.byType(MukzziCharacter));
+      // 400 * 0.45 = 180 (clamp 150~200 범위 내)
+      expect(character.size, 180.0);
+      expect(character.backgroundEdgeFade, isTrue);
+
+      // 히어로 카드 제거 — 남은 BentoCard는 섹션 카드 3개뿐
+      // (영양 달성 / 장착 중 / 도감)
+      expect(find.byType(BentoCard), findsNWidgets(3));
+    });
+
+    testWidgets('넓은 화면에서는 캐릭터 크기가 200px 상한으로 고정된다', (tester) async {
+      tester.view.physicalSize = const Size(900, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(_wrap(_FakeCharacterRepository(_character())));
+      await tester.pump();
+
+      final character =
+          tester.widget<MukzziCharacter>(find.byType(MukzziCharacter));
+      expect(character.size, 200.0);
+    });
+  });
+}

--- a/frontend/test/features/character/equipment_management_page_test.dart
+++ b/frontend/test/features/character/equipment_management_page_test.dart
@@ -392,6 +392,27 @@ void main() {
       expect(preview.backgroundEdgeFade, isTrue);
     });
 
+    testWidgets('중간 화면에서는 프리뷰 크기가 가용 높이에 비례한다', (tester) async {
+      tester.view.physicalSize = const Size(800, 660);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        _wrap(
+          characterRepository: _FakeCharacterRepository(_character()),
+          rewards: [
+            _reward(id: '1', name: '머리 왕관', slot: EquipmentSlot.head),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      final preview =
+          tester.widget<MukzziCharacter>(find.byType(MukzziCharacter));
+      expect(preview.size, greaterThan(80.0));
+      expect(preview.size, lessThan(130.0));
+    });
+
     testWidgets('가용 높이가 380 미만이면 프리뷰를 숨긴다', (tester) async {
       tester.view.physicalSize = const Size(800, 430);
       tester.view.devicePixelRatio = 1.0;

--- a/frontend/test/features/character/equipment_management_page_test.dart
+++ b/frontend/test/features/character/equipment_management_page_test.dart
@@ -366,6 +366,50 @@ void main() {
       expect(find.text('도감 화면'), findsOneWidget);
     });
 
+    testWidgets('프리뷰는 카드·이름 없이 캐릭터만 표시하고 큰 화면에서 130px 상한을 적용한다',
+        (tester) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        _wrap(
+          characterRepository: _FakeCharacterRepository(_character()),
+          rewards: [
+            _reward(id: '1', name: '머리 왕관', slot: EquipmentSlot.head),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(MukzziCharacter), findsOneWidget);
+      // 프리뷰에 캐릭터 이름 텍스트 없음
+      expect(find.text('먹찌'), findsNothing);
+
+      final preview =
+          tester.widget<MukzziCharacter>(find.byType(MukzziCharacter));
+      expect(preview.size, 130.0);
+      expect(preview.backgroundEdgeFade, isTrue);
+    });
+
+    testWidgets('가용 높이가 380 미만이면 프리뷰를 숨긴다', (tester) async {
+      tester.view.physicalSize = const Size(800, 430);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        _wrap(
+          characterRepository: _FakeCharacterRepository(_character()),
+          rewards: [
+            _reward(id: '1', name: '머리 왕관', slot: EquipmentSlot.head),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(MukzziCharacter), findsNothing);
+    });
+
     testWidgets('장착 실패 시 상태가 롤백되고 에러 스낵바가 뜬다', (tester) async {
       final headReward =
           _reward(id: '1', name: '머리 왕관', slot: EquipmentSlot.head);


### PR DESCRIPTION
## Summary
- `MukzziCharacter`에 `backgroundEdgeFade` 옵션 추가 — 배경 슬롯 레이어만 RadialGradient ShaderMask로 가장자리 페이드 (radius 0.5, 변 중앙에서 완전 투명)
- 장착 관리 페이지: 프리뷰 그라데이션 카드·이름 텍스트 제거(시멀리스), 크기를 MediaQuery 고정 분기(450/680) 대신 LayoutBuilder 가용 높이 기반 `clamp(높이×0.18, 80, 130)`으로 계산, 가용 높이 380 미만 시 숨김 — 아이템 그리드 노출 행 증가
- 캐릭터 메인 페이지: 종이질감 히어로 BentoCard 제거, 캐릭터 크기 200 고정 → `clamp(화면폭×0.45, 150, 200)`, 뱃지 텍스트 색 대비 보정(heroText → textPrimary)

## Test Plan
- [x] 신규 위젯 테스트 8개 통과 (페이드 3, 장착 관리 3, 캐릭터 메인 2)
- [x] `flutter analyze` 이슈 0
- [x] 전체 테스트: main 기준선(11 통과/18 실패) 대비 신규 실패 0 — 기존 실패 18개는 main에도 동일 존재
- [ ] 실기기 수동 확인: 배경 아이템 장착 시 페이드 외관, 소형/대형 화면 프리뷰 크기
- [ ] 실기기 수동 확인: 캐릭터 메인 뱃지 필 배경(black 12%) 가시성