### PR TITLE
feat: 홈 히어로 시멀리스 표시 및 장착 관리 칭호 통합

### DIFF
--- a/frontend/lib/src/core/widgets/mukzzi_character.dart
+++ b/frontend/lib/src/core/widgets/mukzzi_character.dart
@@ -412,17 +412,33 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
       fit: BoxFit.contain,
     );
 
-    // 중간 강도 가장자리 페이드: 중심 ~34%는 솔리드, 변 중앙(0.5×변)에서 완전 투명.
-    // radius 0.5 = 변 중앙에서 alpha 0 도달 — 사각 경계가 남지 않는 최대 radius.
+    // 중간 강도 정사각 가장자리 페이드: 각 축에서 중심 68% 구간은 솔리드,
+    // 양 끝 16% 구간에서 알파 0으로 감쇠. 가로/세로 마스크 중첩이라
+    // 모서리는 알파 곱으로 더 빨리 사라진다.
     if (widget.backgroundEdgeFade && config.slot == EquipmentSlot.background) {
+      const fadeColors = [
+        Colors.transparent,
+        Colors.black,
+        Colors.black,
+        Colors.transparent,
+      ];
+      const fadeStops = [0.0, 0.16, 0.84, 1.0];
       layer = ShaderMask(
-        shaderCallback: (bounds) => const RadialGradient(
-          radius: 0.5,
-          colors: [Colors.black, Colors.black, Colors.transparent],
-          stops: [0.0, 0.68, 1.0],
+        shaderCallback: (bounds) => const LinearGradient(
+          colors: fadeColors,
+          stops: fadeStops,
         ).createShader(bounds),
         blendMode: BlendMode.dstIn,
-        child: layer,
+        child: ShaderMask(
+          shaderCallback: (bounds) => const LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: fadeColors,
+            stops: fadeStops,
+          ).createShader(bounds),
+          blendMode: BlendMode.dstIn,
+          child: layer,
+        ),
       );
     }
 

--- a/frontend/lib/src/core/widgets/mukzzi_character.dart
+++ b/frontend/lib/src/core/widgets/mukzzi_character.dart
@@ -425,6 +425,8 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
       const fadeStops = [0.0, 0.16, 0.84, 1.0];
       layer = ShaderMask(
         shaderCallback: (bounds) => const LinearGradient(
+          begin: Alignment.centerLeft,
+          end: Alignment.centerRight,
           colors: fadeColors,
           stops: fadeStops,
         ).createShader(bounds),

--- a/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
@@ -33,9 +33,8 @@ class EquipmentManagementPage extends ConsumerStatefulWidget {
 }
 
 class _EquipmentManagementPageState
-    extends ConsumerState<EquipmentManagementPage>
-    with SingleTickerProviderStateMixin {
-  TabController? _tabController;
+    extends ConsumerState<EquipmentManagementPage> {
+  bool _isTitleMode = false;
   final ScrollController _slotScrollController = ScrollController();
   CharacterModel? _tempCharacter;
   EquipmentSlot? _selectedSlot;
@@ -45,8 +44,7 @@ class _EquipmentManagementPageState
   @override
   void initState() {
     super.initState();
-    final initialTabIndex = widget.initialTab == 'title' ? 0 : 1;
-    _tabController = TabController(length: 2, vsync: this, initialIndex: initialTabIndex);
+    _isTitleMode = widget.initialTab == 'title';
 
     if (widget.initialSlot != null) {
       _selectedSlot = EquipmentSlot.fromJson(widget.initialSlot);
@@ -59,7 +57,6 @@ class _EquipmentManagementPageState
 
   @override
   void dispose() {
-    _tabController?.dispose();
     _slotScrollController.dispose();
     super.dispose();
   }
@@ -218,29 +215,94 @@ class _EquipmentManagementPageState
             .watch(characterProvider)
             .whenData<CharacterModel?>((character) => character);
     final rewardsAsync = ref.watch(rewardListProvider);
+    // pre-watch so data is cached before switching to title mode
+    ref.watch(titleListProvider);
 
     return GradientScaffold(
       appBar: AppBar(
         title: const Text('장착 관리'),
-        bottom: TabBar(
-          controller: _tabController,
-          tabs: const [
-            Tab(text: '칭호'),
-            Tab(text: '아이템'),
-          ],
-        ),
       ),
-      body: TabBarView(
-        controller: _tabController,
-        children: [
-          _buildTitleTab(tokens),
-          _buildItemTab(characterAsync, rewardsAsync, tokens),
-        ],
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final character = _tempCharacter;
+          return Column(
+            children: [
+              if (character != null)
+                _CharacterPreview(
+                  character: character,
+                  availableHeight: constraints.maxHeight,
+                )
+              else
+                const SizedBox.shrink(),
+              _SlotSelector(
+                selectedSlot: _selectedSlot,
+                equipment: character?.equipment ?? {},
+                tokens: tokens,
+                scrollController: _slotScrollController,
+                onSelected: (slot) => setState(() {
+                  _isTitleMode = false;
+                  _selectedSlot = slot;
+                }),
+                isTitleMode: _isTitleMode,
+                onTitleSelected: () => setState(() {
+                  _isTitleMode = true;
+                  _selectedSlot = null;
+                }),
+              ),
+              if (!_isTitleMode)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      ChoiceChip(
+                        label: const Text('획득한 아이템만'),
+                        selected: _showAcquiredOnly,
+                        onSelected: (val) =>
+                            setState(() => _showAcquiredOnly = val),
+                      ),
+                      Text(
+                        '최신순',
+                        style: TextStyle(
+                          color: tokens.textMuted,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              Expanded(
+                child: _isTitleMode
+                    ? _buildTitleContent(tokens)
+                    : (character != null
+                        ? _buildItemGrid(character, rewardsAsync, tokens)
+                        : characterAsync.when(
+                            loading: () =>
+                                const Center(child: CircularProgressIndicator()),
+                            error: (_, __) => CollectionErrorState(
+                              onRetry: _invalidateCharacters,
+                            ),
+                            data: (char) {
+                              if (char == null) {
+                                return const CollectionEmptyState(
+                                  icon: Icons.person_off_outlined,
+                                  title: '캐릭터를 불러오지 못했어요',
+                                  subtitle: '캐릭터가 생성된 뒤 장착을 관리할 수 있어요',
+                                );
+                              }
+                              _tempCharacter = char;
+                              return _buildItemGrid(char, rewardsAsync, tokens);
+                            },
+                          )),
+              ),
+            ],
+          );
+        },
       ),
     );
   }
 
-  Widget _buildTitleTab(AppColorTokens tokens) {
+  Widget _buildTitleContent(AppColorTokens tokens) {
     final titlesAsync = ref.watch(titleListProvider);
     return titlesAsync.when(
       loading: () => const Center(child: CircularProgressIndicator()),
@@ -287,34 +349,7 @@ class _EquipmentManagementPageState
     }
   }
 
-  Widget _buildItemTab(
-    AsyncValue<CharacterModel?> characterAsync,
-    AsyncValue<List<RewardModel>> rewardsAsync,
-    AppColorTokens tokens,
-  ) {
-    final character = _tempCharacter;
-    if (character == null) {
-      return characterAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (_, __) => CollectionErrorState(onRetry: _invalidateCharacters),
-        data: (char) {
-          if (char == null) {
-            return const CollectionEmptyState(
-              icon: Icons.person_off_outlined,
-              title: '캐릭터를 불러오지 못했어요',
-              subtitle: '캐릭터가 생성된 뒤 장착을 관리할 수 있어요',
-            );
-          }
-          _tempCharacter = char;
-          return _buildItemContent(char, rewardsAsync, tokens);
-        },
-      );
-    }
-
-    return _buildItemContent(character, rewardsAsync, tokens);
-  }
-
-  Widget _buildItemContent(
+  Widget _buildItemGrid(
     CharacterModel character,
     AsyncValue<List<RewardModel>> rewardsAsync,
     AppColorTokens tokens,
@@ -329,94 +364,51 @@ class _EquipmentManagementPageState
           final slot = reward.renderConfig?.slot;
           if (slot == null) return false;
 
-          // 획득 여부 필터
           if (_showAcquiredOnly && !reward.acquired) return false;
 
           return _selectedSlot == null || slot == _selectedSlot;
         }).toList();
 
-        return LayoutBuilder(
-          builder: (context, constraints) {
-            return Column(
-              children: [
-                _CharacterPreview(
-                  character: character,
-                  availableHeight: constraints.maxHeight,
-                ),
-                Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      ChoiceChip(
-                        label: const Text('획득한 아이템만'),
-                        selected: _showAcquiredOnly,
-                        onSelected: (val) =>
-                            setState(() => _showAcquiredOnly = val),
-                      ),
-                      Text(
-                        '최신순',
-                        style: TextStyle(
-                          color: tokens.textMuted,
-                          fontSize: 12,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                _SlotSelector(
-                  selectedSlot: _selectedSlot,
-                  equipment: character.equipment,
+        if (candidates.isEmpty) {
+          return const CollectionEmptyState(
+            icon: Icons.inventory_2_outlined,
+            title: '장착할 수 있는 아이템이 없어요',
+            subtitle: '획득한 장착 아이템이 여기에 표시돼요',
+          );
+        }
+
+        return Center(
+          child: SizedBox(
+            width: 480,
+            child: GridView.builder(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+              gridDelegate:
+                  const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                crossAxisSpacing: 10,
+                mainAxisSpacing: 10,
+                childAspectRatio: 1.22,
+              ),
+              itemCount: candidates.length,
+              itemBuilder: (context, index) {
+                final reward = candidates[index];
+                final slot = reward.renderConfig!.slot;
+                final isEquipped =
+                    character.equipment[slot]?.id == reward.id;
+                return _EquipmentRewardCard(
+                  reward: reward,
+                  slot: slot,
+                  isEquipped: isEquipped,
+                  isSubmitting: _isSubmitting,
                   tokens: tokens,
-                  scrollController: _slotScrollController,
-                  onSelected: (slot) => setState(() => _selectedSlot = slot),
-                ),
-                Expanded(
-                  child: candidates.isEmpty
-                      ? const CollectionEmptyState(
-                          icon: Icons.inventory_2_outlined,
-                          title: '장착할 수 있는 아이템이 없어요',
-                          subtitle: '획득한 장착 아이템이 여기에 표시돼요',
-                        )
-                      : Center(
-                          child: SizedBox(
-                            width: 480,
-                            child: GridView.builder(
-                              padding:
-                                  const EdgeInsets.fromLTRB(16, 8, 16, 24),
-                              gridDelegate:
-                                  const SliverGridDelegateWithFixedCrossAxisCount(
-                                crossAxisCount: 2,
-                                crossAxisSpacing: 10,
-                                mainAxisSpacing: 10,
-                                childAspectRatio: 1.22,
-                              ),
-                              itemCount: candidates.length,
-                              itemBuilder: (context, index) {
-                                final reward = candidates[index];
-                                final slot = reward.renderConfig!.slot;
-                                final isEquipped =
-                                    character.equipment[slot]?.id == reward.id;
-                                return _EquipmentRewardCard(
-                                  reward: reward,
-                                  slot: slot,
-                                  isEquipped: isEquipped,
-                                  isSubmitting: _isSubmitting,
-                                  tokens: tokens,
-                                  onTap: () => _toggleEquipment(
-                                    reward: reward,
-                                    isEquipped: isEquipped,
-                                  ),
-                                );
-                              },
-                            ),
-                          ),
-                        ),
-                ),
-              ],
-            );
-          },
+                  onTap: () => _toggleEquipment(
+                    reward: reward,
+                    isEquipped: isEquipped,
+                  ),
+                );
+              },
+            ),
+          ),
         );
       },
     );
@@ -471,6 +463,8 @@ class _SlotSelector extends StatelessWidget {
     required this.tokens,
     required this.onSelected,
     required this.scrollController,
+    required this.isTitleMode,
+    required this.onTitleSelected,
   });
 
   final EquipmentSlot? selectedSlot;
@@ -478,6 +472,8 @@ class _SlotSelector extends StatelessWidget {
   final AppColorTokens tokens;
   final ValueChanged<EquipmentSlot?> onSelected;
   final ScrollController scrollController;
+  final bool isTitleMode;
+  final VoidCallback onTitleSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -504,9 +500,17 @@ class _SlotSelector extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 16),
           children: [
             _SlotChip(
+              label: '칭호',
+              icon: Icons.workspace_premium,
+              selected: isTitleMode,
+              equipped: false,
+              tokens: tokens,
+              onTap: onTitleSelected,
+            ),
+            _SlotChip(
               label: '전체',
               icon: Icons.apps,
-              selected: selectedSlot == null,
+              selected: !isTitleMode && selectedSlot == null,
               equipped: equipment.isNotEmpty,
               tokens: tokens,
               onTap: () => onSelected(null),
@@ -515,7 +519,7 @@ class _SlotSelector extends StatelessWidget {
               (slot) => _SlotChip(
                 label: slot.label,
                 icon: slot.icon,
-                selected: selectedSlot == slot,
+                selected: !isTitleMode && selectedSlot == slot,
                 equipped: equipment.containsKey(slot),
                 tokens: tokens,
                 onTap: () => onSelected(slot),

--- a/frontend/lib/src/features/home/presentation/pages/home_page.dart
+++ b/frontend/lib/src/features/home/presentation/pages/home_page.dart
@@ -48,6 +48,10 @@ class HomePage extends ConsumerStatefulWidget {
 }
 
 class _HomePageState extends ConsumerState<HomePage> {
+  static const double _heroWidthRatio = 0.45;
+  static const double _heroMinCharSize = 150;
+  static const double _heroMaxCharSize = 200;
+
   final GlobalKey _feedMukzziKey = GlobalKey();
   bool _tutorialStarted = false;
 
@@ -318,7 +322,7 @@ class _HomePageState extends ConsumerState<HomePage> {
       padding: EdgeInsets.symmetric(horizontal: 16, vertical: 20),
       child: Column(
         children: [
-          ShimmerCard(height: 320),
+          ShimmerCard(height: 240),
           SizedBox(height: 12),
           ShimmerCard(height: 56),
           SizedBox(height: 12),
@@ -379,7 +383,7 @@ class _HomePageState extends ConsumerState<HomePage> {
           children: [
             characterAsync.when(
               data: (char) => _buildHeroCard(tokens, char),
-              loading: () => const ShimmerCard(height: 320),
+              loading: () => const ShimmerCard(height: 240),
               error: (_, __) => _buildHeroCard(tokens, null),
             ),
             const SizedBox(height: 12),
@@ -599,80 +603,51 @@ class _HomePageState extends ConsumerState<HomePage> {
 
   Widget _buildHeroCard(AppColorTokens tokens, CharacterModel? char) {
     final state = char?.state ?? CharacterState.normal;
-    final name = char?.name ?? '먹찌';
 
-    final card = BentoCard(
-      showPaperTexture: true,
-      borderRadius: BorderRadius.circular(tokens.rHero),
-      padding: const EdgeInsets.fromLTRB(20, 18, 20, 20),
-      shadows: [
-        BoxShadow(
-          color: Colors.black.withValues(alpha: 0.3),
-          blurRadius: 16,
-          offset: const Offset(0, 4),
-        ),
-        BoxShadow(
-          color: state.indicatorColor.withValues(alpha: 0.18),
-          blurRadius: 28,
-          spreadRadius: 2,
-        ),
-      ],
-      child: Column(
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  color: state.indicatorColor,
-                  borderRadius: BorderRadius.circular(20),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(state.icon, size: 11, color: const Color(0xFF1A1A1A)),
-                    const SizedBox(width: 3),
-                    Text(
-                      state.label,
-                      style: const TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.w700,
-                        color: Color(0xFF1A1A1A),
-                      ),
-                    ),
-                  ],
-                ),
+    final hero = Column(
+      children: [
+        Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              decoration: BoxDecoration(
+                color: state.indicatorColor,
+                borderRadius: BorderRadius.circular(20),
               ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          MukzziCharacter(
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(state.icon, size: 11, color: const Color(0xFF1A1A1A)),
+                  const SizedBox(width: 3),
+                  Text(
+                    state.label,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: Color(0xFF1A1A1A),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Center(
+          child: MukzziCharacter(
             state: state,
-            size: 160,
+            size: (MediaQuery.sizeOf(context).width * _heroWidthRatio)
+                .clamp(_heroMinCharSize, _heroMaxCharSize)
+                .toDouble(),
             showAccessory: char?.equippedAccessory != null,
             equippedAccessory: char?.equippedAccessory?.assetUrl,
             equipment: char?.equipment ?? const {},
+            backgroundEdgeFade: true,
           ),
-          const SizedBox(height: 8),
-          Text(
-            name,
-            style: GoogleFonts.poppins(
-              fontSize: 20,
-              fontWeight: FontWeight.w800,
-              color: tokens.heroText,
-            ),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            state.message,
-            style: TextStyle(fontSize: 12, color: tokens.heroTextSub),
-            textAlign: TextAlign.center,
-          ),
-        ],
-      ),
+        ),
+      ],
     );
-    return _animated(card, slideY: true);
+    return _animated(hero, slideY: true);
   }
 
   Widget _buildStreakQuestRow(

--- a/frontend/lib/src/features/home/presentation/pages/home_page.dart
+++ b/frontend/lib/src/features/home/presentation/pages/home_page.dart
@@ -48,6 +48,7 @@ class HomePage extends ConsumerStatefulWidget {
 }
 
 class _HomePageState extends ConsumerState<HomePage> {
+  // 캐릭터 페이지와 동일한 비례 공식 — 비례 동작 구간 333~444px
   static const double _heroWidthRatio = 0.45;
   static const double _heroMinCharSize = 150;
   static const double _heroMaxCharSize = 200;

--- a/frontend/test/core/widgets/mukzzi_character_test.dart
+++ b/frontend/test/core/widgets/mukzzi_character_test.dart
@@ -53,7 +53,8 @@ void main() {
         backgroundEdgeFade: true,
       );
 
-      expect(find.byType(ShaderMask), findsOneWidget);
+      // 정사각 페이드 = 가로/세로 LinearGradient 마스크 중첩 → ShaderMask 2개
+      expect(find.byType(ShaderMask), findsNWidgets(2));
     });
 
     testWidgets('페이드 활성이어도 배경 미장착이면 ShaderMask가 없다', (tester) async {

--- a/frontend/test/features/character/equipment_management_page_test.dart
+++ b/frontend/test/features/character/equipment_management_page_test.dart
@@ -150,6 +150,7 @@ Widget _wrap({
   required _FakeCharacterRepository characterRepository,
   required List<RewardModel> rewards,
   List<TitleModel> titles = const [],
+  String? initialTab,
   GoRouter? router,
 }) {
   final userRepository = _FakeUserRepository();
@@ -175,7 +176,7 @@ Widget _wrap({
           )
         : MaterialApp(
             theme: AppTheme.darkTheme,
-            home: const EquipmentManagementPage(),
+            home: EquipmentManagementPage(initialTab: initialTab),
           ),
   );
 }
@@ -500,25 +501,11 @@ void main() {
       final title2 = _title(id: 't2', name: '연속 도전자');
 
       await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            userRepositoryProvider.overrideWithValue(_FakeUserRepository()),
-            userProvider.overrideWith(
-              (ref) => UserNotifier(_FakeUserRepository(), initialUser: _adminUser),
-            ),
-            characterRepositoryProvider
-                .overrideWithValue(_FakeCharacterRepository(_character())),
-            characterProvider.overrideWith(
-              (ref) => _FakeCharacterRepository(_character()).getMyCharacter(),
-            ),
-            rewardListProvider.overrideWith((ref) async => <RewardModel>[]),
-            titleRepositoryProvider.overrideWithValue(_FakeTitleRepository()),
-            titleListProvider.overrideWith((ref) async => [title1, title2]),
-          ],
-          child: MaterialApp(
-            theme: AppTheme.darkTheme,
-            home: const EquipmentManagementPage(initialTab: 'title'),
-          ),
+        _wrap(
+          characterRepository: _FakeCharacterRepository(_character()),
+          rewards: [],
+          titles: [title1, title2],
+          initialTab: 'title',
         ),
       );
       await tester.pump();

--- a/frontend/test/features/character/equipment_management_page_test.dart
+++ b/frontend/test/features/character/equipment_management_page_test.dart
@@ -130,9 +130,26 @@ CharacterModel _character(
   );
 }
 
+TitleModel _title({
+  required String id,
+  required String name,
+  bool acquired = true,
+  bool isEquipped = false,
+}) {
+  return TitleModel(
+    id: id,
+    code: name,
+    name: name,
+    description: '$name 설명',
+    acquired: acquired,
+    isEquipped: isEquipped,
+  );
+}
+
 Widget _wrap({
   required _FakeCharacterRepository characterRepository,
   required List<RewardModel> rewards,
+  List<TitleModel> titles = const [],
   GoRouter? router,
 }) {
   final userRepository = _FakeUserRepository();
@@ -149,7 +166,7 @@ Widget _wrap({
       ),
       rewardListProvider.overrideWith((ref) async => rewards),
       titleRepositoryProvider.overrideWithValue(_FakeTitleRepository()),
-      titleListProvider.overrideWith((ref) async => <TitleModel>[]),
+      titleListProvider.overrideWith((ref) async => titles),
     ],
     child: router != null
         ? MaterialApp.router(
@@ -474,6 +491,119 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('칭호-아이템 통합', () {
+    testWidgets('initialTab=title이면 칭호 칩이 선택되고 칭호 리스트가 보인다', (tester) async {
+      final title1 = _title(id: 't1', name: '미식가', isEquipped: true);
+      final title2 = _title(id: 't2', name: '연속 도전자');
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            userRepositoryProvider.overrideWithValue(_FakeUserRepository()),
+            userProvider.overrideWith(
+              (ref) => UserNotifier(_FakeUserRepository(), initialUser: _adminUser),
+            ),
+            characterRepositoryProvider
+                .overrideWithValue(_FakeCharacterRepository(_character())),
+            characterProvider.overrideWith(
+              (ref) => _FakeCharacterRepository(_character()).getMyCharacter(),
+            ),
+            rewardListProvider.overrideWith((ref) async => <RewardModel>[]),
+            titleRepositoryProvider.overrideWithValue(_FakeTitleRepository()),
+            titleListProvider.overrideWith((ref) async => [title1, title2]),
+          ],
+          child: MaterialApp(
+            theme: AppTheme.darkTheme,
+            home: const EquipmentManagementPage(initialTab: 'title'),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // 칭호 칩이 선택 상태
+      final titleChip = tester.widget<ChoiceChip>(
+        find.widgetWithText(ChoiceChip, '칭호'),
+      );
+      expect(titleChip.selected, isTrue);
+
+      // 칭호 이름 보임
+      expect(find.text('미식가'), findsOneWidget);
+      expect(find.text('연속 도전자'), findsOneWidget);
+    });
+
+    testWidgets('칭호 칩 탭 시 칭호 리스트로 전환된다', (tester) async {
+      final title1 = _title(id: 't1', name: '미식가');
+      final headReward = _reward(id: '1', name: '머리 왕관', slot: EquipmentSlot.head);
+
+      await tester.pumpWidget(
+        _wrap(
+          characterRepository: _FakeCharacterRepository(_character()),
+          rewards: [headReward],
+          titles: [title1],
+        ),
+      );
+      await tester.pump();
+
+      // 아이템 먼저 보임
+      expect(find.text('머리 왕관'), findsOneWidget);
+
+      // 칭호 칩 탭
+      await tester.tap(find.widgetWithText(ChoiceChip, '칭호'));
+      await tester.pump();
+
+      // 칭호 보이고 아이템 카드 없음
+      expect(find.text('미식가'), findsOneWidget);
+      expect(find.text('머리 왕관'), findsNothing);
+    });
+
+    testWidgets('칭호 선택 후 아이템 칩 탭 시 그리드로 전환된다', (tester) async {
+      final title1 = _title(id: 't1', name: '미식가');
+      final headReward = _reward(id: '1', name: '머리 왕관', slot: EquipmentSlot.head);
+
+      await tester.pumpWidget(
+        _wrap(
+          characterRepository: _FakeCharacterRepository(_character()),
+          rewards: [headReward],
+          titles: [title1],
+        ),
+      );
+      await tester.pump();
+
+      // 칭호 칩 탭
+      await tester.tap(find.widgetWithText(ChoiceChip, '칭호'));
+      await tester.pump();
+      expect(find.text('미식가'), findsOneWidget);
+
+      // 전체 칩 탭 (아이템 전체)
+      await tester.tap(find.widgetWithText(ChoiceChip, '전체'));
+      await tester.pump();
+
+      // 칭호 없고 아이템 그리드
+      expect(find.text('미식가'), findsNothing);
+      expect(find.text('머리 왕관'), findsOneWidget);
+    });
+
+    testWidgets('칭호 모드와 아이템 모드 모두에서 MukzziCharacter가 표시된다', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          characterRepository: _FakeCharacterRepository(_character()),
+          rewards: [],
+        ),
+      );
+      await tester.pump();
+
+      // 아이템 모드: MukzziCharacter 표시
+      expect(find.byType(MukzziCharacter), findsOneWidget);
+
+      // 칭호 모드 전환
+      await tester.tap(find.widgetWithText(ChoiceChip, '칭호'));
+      await tester.pump();
+
+      // 칭호 모드에서도 MukzziCharacter 표시
+      expect(find.byType(MukzziCharacter), findsOneWidget);
     });
   });
 }

--- a/frontend/test/features/home/home_page_test.dart
+++ b/frontend/test/features/home/home_page_test.dart
@@ -1,12 +1,142 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:showcaseview/showcaseview.dart';
+import 'package:mukzzi/src/core/network/api_client.dart';
+import 'package:mukzzi/src/features/notification/data/models/notification_model.dart';
+import 'package:mukzzi/src/features/notification/data/repositories/notification_repository.dart';
+import 'package:mukzzi/src/features/notification/presentation/providers/notification_provider.dart';
+import 'package:mukzzi/src/core/providers/common_providers.dart';
+import 'package:mukzzi/src/core/storage/token_storage.dart';
 import 'package:mukzzi/src/core/theme/app_theme.dart';
+import 'package:mukzzi/src/core/widgets/bento_card.dart';
+import 'package:mukzzi/src/core/widgets/mukzzi_character.dart';
+import 'package:mukzzi/src/features/character/data/models/character_model.dart';
+import 'package:mukzzi/src/features/character/presentation/providers/character_provider.dart';
 import 'package:mukzzi/src/features/home/presentation/pages/home_page.dart';
+import 'package:mukzzi/src/features/home/presentation/providers/nutrition_provider.dart';
+import 'package:mukzzi/src/features/meal_record/presentation/providers/meal_provider.dart';
+import 'package:mukzzi/src/features/profile/data/models/user_model.dart';
+import 'package:mukzzi/src/features/profile/data/repositories/user_repository.dart';
+import 'package:mukzzi/src/features/profile/presentation/providers/user_provider.dart';
+import 'package:mukzzi/src/features/quest/data/repositories/quest_repository_impl.dart';
+import 'package:mukzzi/src/features/quest/domain/entities/quest.dart';
+import 'package:mukzzi/src/features/quest/presentation/providers/quest_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 Widget _wrap(Widget child) => ProviderScope(child: MaterialApp(theme: AppTheme.darkTheme, home: child));
 
+class _FakeTokenStorage implements TokenStorage {
+  @override
+  Future<void> delete(String key) async {}
+
+  @override
+  Future<void> deleteAll(List<String> keys) async {}
+
+  @override
+  Future<String?> read(String key) async => null;
+
+  @override
+  Future<void> write(String key, String value) async {}
+}
+
+class _FakeUserRepository extends UserRepository {
+  _FakeUserRepository() : super(ApiClient(_FakeTokenStorage()));
+
+  @override
+  Future<UserModel> getMe() async => _testUser;
+}
+
+class _FakeNotificationRepository extends NotificationRepository {
+  _FakeNotificationRepository(SharedPreferences prefs)
+      : super(ApiClient(_FakeTokenStorage()), prefs);
+
+  @override
+  Future<List<NotificationModel>> getNotifications(
+          {int limit = 20, String? cursor}) async =>
+      [];
+
+  @override
+  Stream<NotificationModel> subscribeToNotifications() => const Stream.empty();
+
+  @override
+  Future<void> markAsRead(String id) async {}
+
+  @override
+  Future<void> markAllAsRead() async {}
+}
+
+class _FakeQuestRepository implements QuestRepository {
+  @override
+  Future<List<Quest>> getQuests({String? period}) async => [];
+
+  @override
+  Future<void> claimReward(String userQuestId) async {}
+}
+
+final _testUser = UserModel(
+  id: 'user-1',
+  username: 'tester',
+  email: 'tester@example.com',
+);
+
+const _testCharacter = CharacterModel(
+  id: 'character-1',
+  userId: 'user-1',
+  name: '먹찌',
+  state: CharacterState.normal,
+  streakDays: 0,
+  bodyType: 0,
+  muscle: 0,
+  skinTone: 0,
+  expression: 0,
+  nutritionAchievementDays: 0,
+  equipment: {},
+);
+
+Future<Widget> _wrapSeamless() async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final userRepository = _FakeUserRepository();
+  final notificationRepository = _FakeNotificationRepository(prefs);
+
+  return ProviderScope(
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      userRepositoryProvider.overrideWithValue(userRepository),
+      userProvider.overrideWith(
+        (ref) => UserNotifier(userRepository, initialUser: _testUser),
+      ),
+      characterProvider.overrideWith((ref) async => _testCharacter),
+      questRepositoryProvider.overrideWithValue(_FakeQuestRepository()),
+      notificationRepositoryProvider.overrideWithValue(notificationRepository),
+      todayNutritionProvider.overrideWith(
+        (ref) => Future.error(Exception('test')),
+      ),
+      weeklyNutritionProvider.overrideWith(
+        (ref) => Future.error(Exception('test')),
+      ),
+      todayMealsProvider.overrideWith(
+        (ref) => Future.error(Exception('test')),
+      ),
+    ],
+    child: MaterialApp(theme: AppTheme.darkTheme, home: const HomePage()),
+  );
+}
+
 void main() {
+  setUpAll(() async {
+    GoogleFonts.config.allowRuntimeFetching = false;
+    await initializeDateFormatting('ko');
+    ShowcaseView.register();
+  });
+
+  tearDownAll(() {
+    ShowcaseView.get().unregister();
+  });
+
   group('HomePage', () {
     testWidgets('shimmer가 로딩 중 표시된다', (tester) async {
       await tester.pumpWidget(_wrap(const HomePage()));
@@ -50,6 +180,51 @@ void main() {
       await tester.pump(const Duration(milliseconds: 1500));
 
       expect(find.text('이번주 칼로리'), findsOneWidget);
+    });
+  });
+
+  group('HomePage 히어로 시멀리스', () {
+    testWidgets('히어로 카드 없이 캐릭터가 화면폭 비례 크기로 표시된다', (tester) async {
+      tester.view.physicalSize = const Size(400, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(await _wrapSeamless());
+      // pump once to resolve async providers; pump again to drain animate timers
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final character =
+          tester.widget<MukzziCharacter>(find.byType(MukzziCharacter));
+      // 400 * 0.45 = 180 (clamp 150~200 범위 내)
+      expect(character.size, 180.0);
+      expect(character.backgroundEdgeFade, isTrue);
+
+      // 히어로 카드 제거 — 캐릭터가 BentoCard 안에 있지 않음
+      expect(
+        find.ancestor(
+          of: find.byType(MukzziCharacter),
+          matching: find.byType(BentoCard),
+        ),
+        findsNothing,
+      );
+
+      // 이름 텍스트 + 상태 메시지 제거 확인
+      expect(find.text('먹찌'), findsNothing);
+    });
+
+    testWidgets('넓은 화면에서는 캐릭터 크기가 200px 상한으로 고정된다', (tester) async {
+      tester.view.physicalSize = const Size(900, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(await _wrapSeamless());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final character =
+          tester.widget<MukzziCharacter>(find.byType(MukzziCharacter));
+      expect(character.size, 200.0);
     });
   });
 }


### PR DESCRIPTION
## Summary

- 홈 히어로 카드 제거: BentoCard 없애고 캐릭터를 화면에 직접 시멀리스하게 표시 (화면 폭 45%, 150~200px 클램프)
- 배경 페이드 방식 변경: RadialGradient → 두 방향 LinearGradient ShaderMask로 사각형 에지 페이드 적용
- 장착 관리 페이지 칭호 통합: TabBar/TabController 제거, `_isTitleMode` bool로 대체, `_SlotSelector`에 칭호 칩 추가, 캐릭터 프리뷰 항상 표시

## Test Plan

- [ ] 홈 페이지에서 캐릭터가 시멀리스하게 표시되는지 확인
- [ ] 장착 관리 페이지에서 칭호 칩 탭 시 칭호 리스트 표시 확인
- [ ] 칭호 → 아이템 칩 전환 시 그리드로 복귀 확인
- [ ] 양쪽 모드에서 캐릭터 프리뷰 항상 표시 확인
- [ ] 기존 실패 테스트 수 유지 (8개 pre-existing)