### PR TITLE
feat: 캐릭터 상태별 플로팅 파티클 이펙트 + 배경 루프 애니메이션 분리

### DIFF
--- a/frontend/lib/src/core/widgets/mukzzi_character.dart
+++ b/frontend/lib/src/core/widgets/mukzzi_character.dart
@@ -549,7 +549,11 @@ class _FloatingParticles extends StatelessWidget {
         ],
     };
 
-    assert(particles.length == positions.length);
+    assert(
+      particles.length == positions.length,
+      '_FloatingParticles: particles.length (${particles.length}) != '
+      'positions.length (${positions.length}) for state $state',
+    );
 
     return SizedBox(
       width: size,
@@ -566,6 +570,7 @@ class _FloatingParticles extends StatelessWidget {
               style: TextStyle(fontSize: p.fontSize),
             )
                 .animate(onPlay: (c) => c.repeat())
+                // delay workaround: `.animate(delay:)` leaves pending timers in test env
                 .custom(
                   duration: p.delay,
                   builder: (_, __, child) => child,

--- a/frontend/lib/src/core/widgets/mukzzi_character.dart
+++ b/frontend/lib/src/core/widgets/mukzzi_character.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mukzzi/src/features/character/domain/models/reward_model.dart';
 
@@ -98,6 +99,42 @@ extension CharacterStateLabel on CharacterState {
         return const Color(0xFFFF4444);
       case CharacterState.sleeping:
         return const Color(0xFF7C4DFF);
+    }
+  }
+
+  // ignore: library_private_types_in_public_api
+  List<_ParticleData> get particles {
+    switch (this) {
+      case CharacterState.normal:
+        return const [
+          _ParticleData(icon: '✨', delay: Duration.zero,              duration: Duration(milliseconds: 2200)),
+          _ParticleData(icon: '✨', delay: Duration(milliseconds: 700),  duration: Duration(milliseconds: 2000)),
+          _ParticleData(icon: '✨', delay: Duration(milliseconds: 1400), duration: Duration(milliseconds: 2400)),
+        ];
+      case CharacterState.happy:
+        return const [
+          _ParticleData(icon: '♥', delay: Duration.zero,              duration: Duration(milliseconds: 1600)),
+          _ParticleData(icon: '♥', delay: Duration(milliseconds: 500),  duration: Duration(milliseconds: 1400)),
+          _ParticleData(icon: '♥', delay: Duration(milliseconds: 1000), duration: Duration(milliseconds: 1800)),
+        ];
+      case CharacterState.hungry:
+        return const [
+          _ParticleData(icon: '🔥', delay: Duration.zero,              duration: Duration(milliseconds: 1800)),
+          _ParticleData(icon: '🔥', delay: Duration(milliseconds: 600),  duration: Duration(milliseconds: 1600)),
+          _ParticleData(icon: '🔥', delay: Duration(milliseconds: 1200), duration: Duration(milliseconds: 2000)),
+        ];
+      case CharacterState.starving:
+        return const [
+          _ParticleData(icon: '⚠️', delay: Duration.zero,              duration: Duration(milliseconds: 1000)),
+          _ParticleData(icon: '⚠️', delay: Duration(milliseconds: 300),  duration: Duration(milliseconds: 900)),
+          _ParticleData(icon: '⚠️', delay: Duration(milliseconds: 600),  duration: Duration(milliseconds: 1100)),
+        ];
+      case CharacterState.sleeping:
+        return const [
+          _ParticleData(icon: 'z', delay: Duration.zero,              duration: Duration(milliseconds: 2800), fontSize: 14),
+          _ParticleData(icon: 'z', delay: Duration(milliseconds: 900),  duration: Duration(milliseconds: 2800), fontSize: 18),
+          _ParticleData(icon: 'z', delay: Duration(milliseconds: 1800), duration: Duration(milliseconds: 2800), fontSize: 22),
+        ];
     }
   }
 }
@@ -363,6 +400,7 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
           for (final spec in backgroundSpecs) _buildLayer(spec),
           // 캐릭터 + 비배경 장비: 루프 애니메이션
           animatedCharacter,
+          _FloatingParticles(state: widget.state, size: widget.size),
         ],
       ),
     );
@@ -473,6 +511,83 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
           angle: config.rotation * math.pi / 180,
           child: Center(child: layer),
         ),
+      ),
+    );
+  }
+}
+
+class _ParticleData {
+  final String icon;
+  final Duration delay;
+  final Duration duration;
+  final double fontSize;
+
+  const _ParticleData({
+    required this.icon,
+    required this.delay,
+    required this.duration,
+    this.fontSize = 18,
+  });
+}
+
+class _FloatingParticles extends StatelessWidget {
+  final CharacterState state;
+  final double size;
+
+  const _FloatingParticles({required this.state, required this.size});
+
+  // 파티클 위치: 좌상 / 우상 / 상단 중앙
+  static const _positions = [
+    (leftRatio: 0.15, topRatio: 0.30),
+    (leftRatio: 0.65, topRatio: 0.28),
+    (leftRatio: 0.40, topRatio: 0.20),
+  ];
+
+  // sleeping: 우측으로 몰아서 오름
+  static const _sleepingPositions = [
+    (leftRatio: 0.60, topRatio: 0.40),
+    (leftRatio: 0.68, topRatio: 0.28),
+    (leftRatio: 0.74, topRatio: 0.14),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final particles = state.particles;
+    final positions = state == CharacterState.sleeping
+        ? _sleepingPositions
+        : _positions;
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        children: List.generate(particles.length, (i) {
+          final p = particles[i];
+          final pos = positions[i];
+          return Positioned(
+            left: size * pos.leftRatio,
+            top: size * pos.topRatio,
+            child: Text(
+              p.icon,
+              style: TextStyle(fontSize: p.fontSize),
+            )
+                .animate(onPlay: (c) => c.repeat())
+                .custom(
+                  duration: p.delay,
+                  builder: (_, __, child) => child,
+                )
+                .then()
+                .moveY(
+                  begin: 0,
+                  end: -size * 0.35,
+                  duration: p.duration,
+                  curve: Curves.easeOut,
+                )
+                .fadeIn(duration: p.duration * 0.15)
+                .then(delay: p.duration * 0.55)
+                .fadeOut(duration: p.duration * 0.30),
+          );
+        }),
       ),
     );
   }

--- a/frontend/lib/src/core/widgets/mukzzi_character.dart
+++ b/frontend/lib/src/core/widgets/mukzzi_character.dart
@@ -102,41 +102,6 @@ extension CharacterStateLabel on CharacterState {
     }
   }
 
-  // ignore: library_private_types_in_public_api
-  List<_ParticleData> get particles {
-    switch (this) {
-      case CharacterState.normal:
-        return const [
-          _ParticleData(icon: '✨', delay: Duration.zero,              duration: Duration(milliseconds: 2200)),
-          _ParticleData(icon: '✨', delay: Duration(milliseconds: 700),  duration: Duration(milliseconds: 2000)),
-          _ParticleData(icon: '✨', delay: Duration(milliseconds: 1400), duration: Duration(milliseconds: 2400)),
-        ];
-      case CharacterState.happy:
-        return const [
-          _ParticleData(icon: '♥', delay: Duration.zero,              duration: Duration(milliseconds: 1600)),
-          _ParticleData(icon: '♥', delay: Duration(milliseconds: 500),  duration: Duration(milliseconds: 1400)),
-          _ParticleData(icon: '♥', delay: Duration(milliseconds: 1000), duration: Duration(milliseconds: 1800)),
-        ];
-      case CharacterState.hungry:
-        return const [
-          _ParticleData(icon: '🔥', delay: Duration.zero,              duration: Duration(milliseconds: 1800)),
-          _ParticleData(icon: '🔥', delay: Duration(milliseconds: 600),  duration: Duration(milliseconds: 1600)),
-          _ParticleData(icon: '🔥', delay: Duration(milliseconds: 1200), duration: Duration(milliseconds: 2000)),
-        ];
-      case CharacterState.starving:
-        return const [
-          _ParticleData(icon: '⚠️', delay: Duration.zero,              duration: Duration(milliseconds: 1000)),
-          _ParticleData(icon: '⚠️', delay: Duration(milliseconds: 300),  duration: Duration(milliseconds: 900)),
-          _ParticleData(icon: '⚠️', delay: Duration(milliseconds: 600),  duration: Duration(milliseconds: 1100)),
-        ];
-      case CharacterState.sleeping:
-        return const [
-          _ParticleData(icon: 'z', delay: Duration.zero,              duration: Duration(milliseconds: 2800), fontSize: 14),
-          _ParticleData(icon: 'z', delay: Duration(milliseconds: 900),  duration: Duration(milliseconds: 2800), fontSize: 18),
-          _ParticleData(icon: 'z', delay: Duration(milliseconds: 1800), duration: Duration(milliseconds: 2800), fontSize: 22),
-        ];
-    }
-  }
 }
 
 class MukzziCharacter extends StatelessWidget {
@@ -552,10 +517,39 @@ class _FloatingParticles extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final particles = state.particles;
     final positions = state == CharacterState.sleeping
         ? _sleepingPositions
         : _positions;
+
+    final particles = switch (state) {
+      CharacterState.normal => const [
+          _ParticleData(icon: '✨', delay: Duration.zero, duration: Duration(milliseconds: 2200)),
+          _ParticleData(icon: '✨', delay: Duration(milliseconds: 700), duration: Duration(milliseconds: 2000)),
+          _ParticleData(icon: '✨', delay: Duration(milliseconds: 1400), duration: Duration(milliseconds: 2400)),
+        ],
+      CharacterState.happy => const [
+          _ParticleData(icon: '♥', delay: Duration.zero, duration: Duration(milliseconds: 1600)),
+          _ParticleData(icon: '♥', delay: Duration(milliseconds: 500), duration: Duration(milliseconds: 1400)),
+          _ParticleData(icon: '♥', delay: Duration(milliseconds: 1000), duration: Duration(milliseconds: 1800)),
+        ],
+      CharacterState.hungry => const [
+          _ParticleData(icon: '🔥', delay: Duration.zero, duration: Duration(milliseconds: 1800)),
+          _ParticleData(icon: '🔥', delay: Duration(milliseconds: 600), duration: Duration(milliseconds: 1600)),
+          _ParticleData(icon: '🔥', delay: Duration(milliseconds: 1200), duration: Duration(milliseconds: 2000)),
+        ],
+      CharacterState.starving => const [
+          _ParticleData(icon: '⚠️', delay: Duration.zero, duration: Duration(milliseconds: 1000)),
+          _ParticleData(icon: '⚠️', delay: Duration(milliseconds: 300), duration: Duration(milliseconds: 900)),
+          _ParticleData(icon: '⚠️', delay: Duration(milliseconds: 600), duration: Duration(milliseconds: 1100)),
+        ],
+      CharacterState.sleeping => const [
+          _ParticleData(icon: 'z', delay: Duration.zero, duration: Duration(milliseconds: 2800), fontSize: 14),
+          _ParticleData(icon: 'z', delay: Duration(milliseconds: 900), duration: Duration(milliseconds: 2800), fontSize: 18),
+          _ParticleData(icon: 'z', delay: Duration(milliseconds: 1800), duration: Duration(milliseconds: 2800), fontSize: 22),
+        ],
+    };
+
+    assert(particles.length == positions.length);
 
     return SizedBox(
       width: size,

--- a/frontend/lib/src/core/widgets/mukzzi_character.dart
+++ b/frontend/lib/src/core/widgets/mukzzi_character.dart
@@ -311,27 +311,33 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
   Widget build(BuildContext context) {
     final bodyPath = _path('body');
     final equipmentLayers = _equipmentLayers();
-    final specs = <_CharacterLayerSpec>[
+
+    // 배경과 비배경 분리 (slot 기준)
+    final backgroundSpecs = <_CharacterLayerSpec>[
       for (final item in equipmentLayers)
-        if ((item.renderConfig?.zIndex ?? 30) < 0)
-          _CharacterLayerSpec.equipment(item),
-      _CharacterLayerSpec.asset(bodyPath, 0),
-      for (final item in equipmentLayers)
-        if ((item.renderConfig?.zIndex ?? 30) >= 0)
+        if (item.renderConfig?.slot == EquipmentSlot.background)
           _CharacterLayerSpec.equipment(item),
     ]..sort((a, b) => a.zIndex.compareTo(b.zIndex));
 
-    final svgStack = SizedBox(
+    final characterSpecs = <_CharacterLayerSpec>[
+      for (final item in equipmentLayers)
+        if (item.renderConfig?.slot != EquipmentSlot.background)
+          _CharacterLayerSpec.equipment(item),
+      _CharacterLayerSpec.asset(bodyPath, 0),
+    ]..sort((a, b) => a.zIndex.compareTo(b.zIndex));
+
+    final characterStack = SizedBox(
       width: widget.size,
       height: widget.size,
       child: Stack(
-        children: specs.map(_buildLayer).toList(),
+        children: characterSpecs.map(_buildLayer).toList(),
       ),
     );
 
-    return AnimatedBuilder(
+    final animatedCharacter = AnimatedBuilder(
+      key: const ValueKey('character_loop'),
       animation: _anim,
-      child: svgStack,
+      child: characterStack,
       builder: (_, child) => switch (widget.state) {
         CharacterState.sleeping => Transform.scale(
             scale: _anim.value,
@@ -346,6 +352,19 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
             child: child,
           ),
       },
+    );
+
+    return SizedBox(
+      width: widget.size,
+      height: widget.size,
+      child: Stack(
+        children: [
+          // 배경: Transform 없이 정적
+          for (final spec in backgroundSpecs) _buildLayer(spec),
+          // 캐릭터 + 비배경 장비: 루프 애니메이션
+          animatedCharacter,
+        ],
+      ),
     );
   }
 

--- a/frontend/test/core/widgets/mukzzi_character_test.dart
+++ b/frontend/test/core/widgets/mukzzi_character_test.dart
@@ -118,6 +118,20 @@ void main() {
       await tester.pumpWidget(const SizedBox());
     });
 
+    testWidgets('hungry 상태에서 🔥 파티클이 3개 존재한다', (tester) async {
+      await pumpWithState(tester, CharacterState.hungry);
+      expect(find.text('🔥'), findsNWidgets(3));
+      await tester.pump(Duration.zero);
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('starving 상태에서 ⚠️ 파티클이 3개 존재한다', (tester) async {
+      await pumpWithState(tester, CharacterState.starving);
+      expect(find.text('⚠️'), findsNWidgets(3));
+      await tester.pump(Duration.zero);
+      await tester.pumpWidget(const SizedBox());
+    });
+
     testWidgets('상태 전환 시 이전 파티클이 사라지고 새 파티클이 나타난다', (tester) async {
       final key = GlobalKey();
       CharacterState currentState = CharacterState.normal;

--- a/frontend/test/core/widgets/mukzzi_character_test.dart
+++ b/frontend/test/core/widgets/mukzzi_character_test.dart
@@ -75,6 +75,91 @@ void main() {
         find.descendant(of: loopFinder, matching: find.byKey(bgSvgKey)),
         findsNothing,
       );
+      await tester.pump(Duration.zero);
+      await tester.pumpWidget(const SizedBox());
+    });
+  });
+
+  group('_FloatingParticles', () {
+    Future<void> pumpWithState(
+      WidgetTester tester,
+      CharacterState state,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: MukzziCharacter(state: state, size: 200),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+    }
+
+    testWidgets('normal 상태에서 ✨ 파티클이 3개 존재한다', (tester) async {
+      await pumpWithState(tester, CharacterState.normal);
+      expect(find.text('✨'), findsNWidgets(3));
+      await tester.pump(Duration.zero);
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('happy 상태에서 ♥ 파티클이 3개 존재한다', (tester) async {
+      await pumpWithState(tester, CharacterState.happy);
+      expect(find.text('♥'), findsNWidgets(3));
+      await tester.pump(Duration.zero);
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('sleeping 상태에서 z 파티클이 3개 존재한다', (tester) async {
+      await pumpWithState(tester, CharacterState.sleeping);
+      expect(find.text('z'), findsNWidgets(3));
+      await tester.pump(Duration.zero);
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('상태 전환 시 이전 파티클이 사라지고 새 파티클이 나타난다', (tester) async {
+      final key = GlobalKey();
+      CharacterState currentState = CharacterState.normal;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StatefulBuilder(
+            builder: (context, setState) => Scaffold(
+              body: Center(
+                child: MukzziCharacter(
+                  key: key,
+                  state: currentState,
+                  size: 200,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('✨'), findsNWidgets(3));
+
+      // 상태 변경
+      currentState = CharacterState.happy;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: MukzziCharacter(
+                key: key,
+                state: currentState,
+                size: 200,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('♥'), findsNWidgets(3));
+      expect(find.text('✨'), findsNothing);
+      await tester.pump(Duration.zero);
+      await tester.pumpWidget(const SizedBox());
     });
   });
 
@@ -89,6 +174,8 @@ void main() {
 
       // 정사각 페이드 = 가로/세로 LinearGradient 마스크 중첩 → ShaderMask 2개
       expect(find.byType(ShaderMask), findsNWidgets(2));
+      await tester.pump(Duration.zero);
+      await tester.pumpWidget(const SizedBox());
     });
 
     testWidgets('페이드 활성이어도 배경 미장착이면 ShaderMask가 없다', (tester) async {
@@ -99,6 +186,8 @@ void main() {
       );
 
       expect(find.byType(ShaderMask), findsNothing);
+      await tester.pump(Duration.zero);
+      await tester.pumpWidget(const SizedBox());
     });
 
     testWidgets('기본값(false)이면 배경을 장착해도 ShaderMask가 없다', (tester) async {
@@ -109,6 +198,8 @@ void main() {
       );
 
       expect(find.byType(ShaderMask), findsNothing);
+      await tester.pump(Duration.zero);
+      await tester.pumpWidget(const SizedBox());
     });
   });
 }

--- a/frontend/test/core/widgets/mukzzi_character_test.dart
+++ b/frontend/test/core/widgets/mukzzi_character_test.dart
@@ -44,6 +44,40 @@ Future<void> _pumpCharacter(
 }
 
 void main() {
+  group('MukzziCharacter 배경 레이어 분리', () {
+    testWidgets('배경 장착 시 AnimatedBuilder는 1개만 존재한다', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: MukzziCharacter(
+                equipment: {EquipmentSlot.background: _backgroundReward()},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // flutter_svg는 내부적으로 AnimatedBuilder를 추가하므로
+      // 전체 카운트 대신 구조적으로 검증한다:
+      // - character_loop 빌더가 존재해야 함
+      // - 배경 SVG는 character_loop 밖에 있어야 함
+      const loopKey = ValueKey('character_loop');
+      const bgSvgKey = ValueKey('assets/svg/mukzzi2_background_kitchen.svg');
+
+      final loopFinder = find.byKey(loopKey);
+      expect(loopFinder, findsOneWidget);
+      expect(find.byKey(bgSvgKey), findsOneWidget);
+
+      // 배경은 루프 애니메이션 밖에 위치해야 함
+      expect(
+        find.descendant(of: loopFinder, matching: find.byKey(bgSvgKey)),
+        findsNothing,
+      );
+    });
+  });
+
   group('MukzziCharacter backgroundEdgeFade', () {
     testWidgets('페이드 활성 + 배경 장착 시 배경 레이어에 ShaderMask를 적용한다',
         (tester) async {


### PR DESCRIPTION
## Summary

- 배경 레이어(`EquipmentSlot.background`)를 루프 애니메이션 Transform 밖으로 분리 — 배경이 더 이상 흔들리지 않음
- 상태별 플로팅 파티클 오버레이 추가 (항시 표시): normal ✨ / happy ♥ / hungry 🔥 / starving ⚠️ / sleeping z
- `flutter_animate` 루프로 구현, 파티클 3개씩 delay 차이를 줘 자연스러운 흐름

## Test Plan

- [ ] 배경 장비(kitchen, night) 장착 후 상태 전환 시 배경이 흔들리지 않는지 확인
- [ ] 홈 화면에서 5가지 상태 각각 파티클 표시 확인
- [ ] 상태 전환 시 이전 파티클 잔류 없이 교체되는지 확인
- [ ] `flutter test test/core/widgets/mukzzi_character_test.dart` — 10/10 PASS