### PR TITLE
fix: 알림 전체읽음 트랜지션·모드별 읽음 위계 보완

### DIFF
--- a/frontend/lib/src/features/notification/presentation/pages/notification_list_page.dart
+++ b/frontend/lib/src/features/notification/presentation/pages/notification_list_page.dart
@@ -20,17 +20,29 @@ class NotificationListPage extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('알림'),
         actions: [
-          if (state.unreadCount > 0)
-            Padding(
-              padding: const EdgeInsets.only(right: 8.0),
-              child: TextButton(
-                onPressed: () => notifier.markAllAsRead(),
-                style: TextButton.styleFrom(
-                  foregroundColor: Theme.of(context).extension<AppColorTokens>()!.primary,
-                ),
-                child: const Text('전체 읽음', style: TextStyle(fontWeight: FontWeight.w600)),
-              ),
-            ),
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 250),
+            transitionBuilder: (child, animation) =>
+                FadeTransition(opacity: animation, child: child),
+            child: state.unreadCount > 0
+                ? Padding(
+                    key: const ValueKey('mark-all-read'),
+                    padding: const EdgeInsets.only(right: 8.0),
+                    child: TextButton(
+                      onPressed: () => notifier.markAllAsRead(),
+                      style: TextButton.styleFrom(
+                        foregroundColor: Theme.of(context)
+                            .extension<AppColorTokens>()!
+                            .primary,
+                      ),
+                      child: const Text(
+                        '전체 읽음',
+                        style: TextStyle(fontWeight: FontWeight.w600),
+                      ),
+                    ),
+                  )
+                : const SizedBox.shrink(key: ValueKey('mark-all-empty')),
+          ),
         ],
       ),
       body: RefreshIndicator(
@@ -54,7 +66,7 @@ class NotificationListPage extends ConsumerWidget {
                         onTap: () {
                           // 1. 읽음 처리
                           if (!n.isRead) notifier.markAsRead(n.id);
-                          
+
                           // 2. 관련 페이지로 이동 (Navigator 키 충돌 방지를 위해 go 사용)
                           WidgetsBinding.instance.addPostFrameCallback((_) {
                             if (context.mounted) {
@@ -82,7 +94,7 @@ class _NotificationItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = Theme.of(context).extension<AppColorTokens>()!;
-    
+
     return InkWell(
       onTap: onTap,
       borderRadius: BorderRadius.circular(tokens.rItem),
@@ -90,19 +102,18 @@ class _NotificationItem extends StatelessWidget {
         duration: const Duration(milliseconds: 200),
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: notification.isRead 
-              ? tokens.listItemBg.withValues(alpha: 0.4) 
-              : tokens.card,
+          color: notification.isRead ? tokens.listItemBg : tokens.card,
           borderRadius: BorderRadius.circular(tokens.rItem),
           border: Border.all(
-            color: notification.isRead 
-                ? Colors.transparent 
-                : tokens.primary.withValues(alpha: 0.2), 
+            color: notification.isRead
+                ? tokens.textMuted.withValues(alpha: 0.12)
+                : tokens.primary.withValues(alpha: 0.2),
             width: 1.5,
           ),
-          boxShadow: notification.isRead ? null : [
+          boxShadow: [
             BoxShadow(
-              color: Colors.black.withValues(alpha: 0.08),
+              color: Colors.black
+                  .withValues(alpha: notification.isRead ? 0.0 : 0.08),
               blurRadius: 12,
               offset: const Offset(0, 4),
             ),
@@ -121,51 +132,70 @@ class _NotificationItem extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       Expanded(
-                        child: Text(
-                          notification.title,
+                        child: AnimatedDefaultTextStyle(
+                          duration: const Duration(milliseconds: 200),
                           style: TextStyle(
                             fontSize: 14,
-                            fontWeight: notification.isRead ? FontWeight.w600 : FontWeight.w800,
-                            color: notification.isRead ? tokens.textSub : tokens.textPrimary,
+                            fontWeight: notification.isRead
+                                ? FontWeight.w600
+                                : FontWeight.w800,
+                            color: notification.isRead
+                                ? tokens.textSub
+                                : tokens.textPrimary,
                           ),
+                          child: Text(notification.title),
                         ),
                       ),
                       const SizedBox(width: 8),
                       Text(
                         _formatTime(notification.createdAt),
-                        style: TextStyle(fontSize: 11, color: tokens.textMuted, fontWeight: FontWeight.w500),
+                        style: TextStyle(
+                            fontSize: 11,
+                            color: tokens.textMuted,
+                            fontWeight: FontWeight.w500),
                       ),
                     ],
                   ),
                   const SizedBox(height: 6),
-                  Text(
-                    notification.content,
+                  AnimatedDefaultTextStyle(
+                    duration: const Duration(milliseconds: 200),
                     style: TextStyle(
                       fontSize: 13,
-                      color: notification.isRead ? tokens.textMuted : tokens.textSub,
+                      color: notification.isRead
+                          ? tokens.textMuted
+                          : tokens.textSub,
                       height: 1.5,
                     ),
+                    child: Text(notification.content),
                   ),
                 ],
               ),
             ),
-            if (!notification.isRead)
-              Container(
-                margin: const EdgeInsets.only(left: 10, top: 4),
-                width: 10,
-                height: 10,
-                decoration: BoxDecoration(
-                  color: tokens.primary,
-                  shape: BoxShape.circle,
-                  boxShadow: [
-                    BoxShadow(
-                      color: tokens.primary.withValues(alpha: 0.4),
-                      blurRadius: 6,
-                      spreadRadius: 1,
-                    ),
-                  ],
+            AnimatedScale(
+              duration: const Duration(milliseconds: 200),
+              scale: notification.isRead ? 0.0 : 1.0,
+              child: AnimatedOpacity(
+                duration: const Duration(milliseconds: 200),
+                opacity: notification.isRead ? 0.0 : 1.0,
+                child: Container(
+                  key: const ValueKey('notif-unread-dot'),
+                  margin: const EdgeInsets.only(left: 10, top: 4),
+                  width: 10,
+                  height: 10,
+                  decoration: BoxDecoration(
+                    color: tokens.primary,
+                    shape: BoxShape.circle,
+                    boxShadow: [
+                      BoxShadow(
+                        color: tokens.primary.withValues(alpha: 0.4),
+                        blurRadius: 6,
+                        spreadRadius: 1,
+                      ),
+                    ],
+                  ),
                 ),
               ),
+            ),
           ],
         ),
       ),

--- a/frontend/test/features/notification/notification_list_page_test.dart
+++ b/frontend/test/features/notification/notification_list_page_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mukzzi/src/core/network/api_client.dart';
+import 'package:mukzzi/src/core/providers/common_providers.dart';
+import 'package:mukzzi/src/core/storage/token_storage.dart';
+import 'package:mukzzi/src/core/theme/app_theme.dart';
+import 'package:mukzzi/src/features/notification/data/models/notification_model.dart';
+import 'package:mukzzi/src/features/notification/data/repositories/notification_repository.dart';
+import 'package:mukzzi/src/features/notification/presentation/pages/notification_list_page.dart';
+import 'package:mukzzi/src/features/notification/presentation/providers/notification_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeTokenStorage implements TokenStorage {
+  @override
+  Future<void> delete(String key) async {}
+  @override
+  Future<void> deleteAll(List<String> keys) async {}
+  @override
+  Future<String?> read(String key) async => null;
+  @override
+  Future<void> write(String key, String value) async {}
+}
+
+NotificationModel _notif({required String id, required bool isRead}) =>
+    NotificationModel(
+      id: id,
+      userId: 'user-1',
+      type: NotificationType.nudge,
+      title: '제목 $id',
+      content: '내용 $id',
+      isRead: isRead,
+      createdAt: DateTime.now(),
+    );
+
+class _FakeNotificationRepository extends NotificationRepository {
+  _FakeNotificationRepository(SharedPreferences prefs)
+      : super(ApiClient(_FakeTokenStorage()), prefs);
+
+  @override
+  Future<List<NotificationModel>> getNotifications(
+          {int limit = 20, String? cursor}) async =>
+      [_notif(id: 'a', isRead: false), _notif(id: 'b', isRead: true)];
+
+  @override
+  Stream<NotificationModel> subscribeToNotifications() => const Stream.empty();
+
+  // No-op: NotificationNotifier flips isRead in its own state after awaiting
+  // these. The stubs only prevent real HTTP — the button-disappears assertion
+  // passes because of the notifier's state update, not a repository response.
+  @override
+  Future<void> markAsRead(String id) async {}
+
+  @override
+  Future<void> markAllAsRead() async {}
+}
+
+Future<Widget> _wrap() async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  return ProviderScope(
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      notificationRepositoryProvider
+          .overrideWithValue(_FakeNotificationRepository(prefs)),
+    ],
+    child: MaterialApp(
+      theme: AppTheme.darkTheme,
+      home: const NotificationListPage(),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  testWidgets('안 읽은 알림이 있으면 전체 읽음 버튼이 보이고, 탭하면 사라진다', (tester) async {
+    await tester.pumpWidget(await _wrap());
+    await tester.pumpAndSettle();
+
+    expect(find.text('전체 읽음'), findsOneWidget);
+
+    await tester.tap(find.text('전체 읽음'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('전체 읽음'), findsNothing);
+  });
+
+  testWidgets('읽음 여부와 무관하게 안읽음 점이 트리에 유지된다', (tester) async {
+    await tester.pumpWidget(await _wrap());
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('notif-unread-dot')), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
## 요약
알림 목록의 읽음/안읽음 전환을 부드럽게 하고, 다크모드 읽음 위계 역전을 바로잡음. 단일 파일(`notification_list_page.dart`) + 위젯 테스트.

## 변경
- **그림자**: `boxShadow` 상시 렌더 + alpha 페이드(0.08→0.0) — 기존엔 list↔null lerp로 blur가 쪼그라들며 사라짐
- **텍스트**: 제목·본문 `AnimatedDefaultTextStyle(200ms)` — fontWeight·color 트랜지션
- **전체읽음 버튼**: `AnimatedSwitcher(250ms)` 페이드 (즉시 사라짐 → 페이드)
- **다크 읽음 위계**: 읽음 bg `listItemBg.withValues(alpha:0.4)` 제거 → 토큰 원본 + `textMuted@12%` 헤어라인. (기존엔 다크에서 읽음이 안읽음보다 밝게 보이는 역전)
- **안읽음 점**: 상시 트리 상주 + `AnimatedScale`/`AnimatedOpacity` 페이드아웃 (`ValueKey('notif-unread-dot')`)

## 테스트
- `notification_list_page_test.dart` 신규: 전체읽음 버튼 가시성 + 안읽음 점 트리 상주 (2/2 통과, TDD RED→GREEN)
- `flutter analyze` 무경고

## 검증 메모
- 라이트모드 읽음 항목(peach@60%) 육안 확인 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)