### PR TITLE
fix: 라이트모드 가독성·테마 토큰 정비 (테마 감사 C1/H/M)

### DIFF
--- a/frontend/lib/src/core/theme/app_theme.dart
+++ b/frontend/lib/src/core/theme/app_theme.dart
@@ -85,6 +85,7 @@ class AppColorTokens extends ThemeExtension<AppColorTokens> {
   final Color heroTextSub;
   final Color paper;
   final Color paperLine;
+  final Color divider;
   final Gradient bgGrad;
   final Gradient cardHeroGrad;
   final Gradient charBgNormal;
@@ -108,6 +109,7 @@ class AppColorTokens extends ThemeExtension<AppColorTokens> {
     required this.heroTextSub,
     required this.paper,
     required this.paperLine,
+    required this.divider,
     required this.bgGrad,
     required this.cardHeroGrad,
     required this.charBgNormal,
@@ -132,6 +134,7 @@ class AppColorTokens extends ThemeExtension<AppColorTokens> {
     heroTextSub: Color(0xA63A2010),
     paper: Color(0xFFFAFAFA),
     paperLine: Color(0x14000000),
+    divider: Color(0x1FFBF4E8),
     bgGrad: LinearGradient(
       colors: [Color(0xFF14110E), Color(0xFF1C1611)],
       begin: Alignment.topCenter,
@@ -173,6 +176,7 @@ class AppColorTokens extends ThemeExtension<AppColorTokens> {
     heroTextSub: AppColors.lightTextSecondary,
     paper: Color(0xFFFAFAFA),
     paperLine: Color(0x14000000),
+    divider: AppColors.lightDivider,
     bgGrad: LinearGradient(
       colors: [AppColors.lightBackground, Color(0xFFF8EFE3)],
       begin: Alignment.topCenter,
@@ -215,6 +219,7 @@ class AppColorTokens extends ThemeExtension<AppColorTokens> {
     Color? heroTextSub,
     Color? paper,
     Color? paperLine,
+    Color? divider,
     Gradient? bgGrad,
     Gradient? cardHeroGrad,
     Gradient? charBgNormal,
@@ -238,6 +243,7 @@ class AppColorTokens extends ThemeExtension<AppColorTokens> {
       heroTextSub: heroTextSub ?? this.heroTextSub,
       paper: paper ?? this.paper,
       paperLine: paperLine ?? this.paperLine,
+      divider: divider ?? this.divider,
       bgGrad: bgGrad ?? this.bgGrad,
       cardHeroGrad: cardHeroGrad ?? this.cardHeroGrad,
       charBgNormal: charBgNormal ?? this.charBgNormal,
@@ -266,6 +272,7 @@ class AppColorTokens extends ThemeExtension<AppColorTokens> {
       heroTextSub: Color.lerp(heroTextSub, other.heroTextSub, t)!,
       paper: Color.lerp(paper, other.paper, t)!,
       paperLine: Color.lerp(paperLine, other.paperLine, t)!,
+      divider: Color.lerp(divider, other.divider, t)!,
       // Gradient lerp across dark↔light is jarring; snap at midpoint
       bgGrad: t < 0.5 ? bgGrad : other.bgGrad,
       cardHeroGrad: t < 0.5 ? cardHeroGrad : other.cardHeroGrad,

--- a/frontend/lib/src/features/home/presentation/widgets/menu_decision_section.dart
+++ b/frontend/lib/src/features/home/presentation/widgets/menu_decision_section.dart
@@ -684,9 +684,9 @@ class _FilterSection extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const SizedBox(height: 14),
-          const Text(
+          Text(
             '날씨',
-            style: TextStyle(fontSize: 12, color: Colors.grey, fontWeight: FontWeight.w600),
+            style: TextStyle(fontSize: 12, color: tokens.textMuted, fontWeight: FontWeight.w600),
           ),
           const SizedBox(height: 8),
           Wrap(
@@ -703,9 +703,9 @@ class _FilterSection extends ConsumerWidget {
             }).toList(),
           ),
           const SizedBox(height: 12),
-          const Text(
+          Text(
             '기분',
-            style: TextStyle(fontSize: 12, color: Colors.grey, fontWeight: FontWeight.w600),
+            style: TextStyle(fontSize: 12, color: tokens.textMuted, fontWeight: FontWeight.w600),
           ),
           const SizedBox(height: 8),
           Wrap(

--- a/frontend/lib/src/features/meal_record/presentation/pages/meal_record_page.dart
+++ b/frontend/lib/src/features/meal_record/presentation/pages/meal_record_page.dart
@@ -260,7 +260,8 @@ class _MealRecordPageState extends ConsumerState<MealRecordPage>
           controller: _tabController,
           indicatorColor: Theme.of(context).primaryColor,
           labelColor: Theme.of(context).primaryColor,
-          unselectedLabelColor: Colors.grey,
+          unselectedLabelColor:
+              Theme.of(context).extension<AppColorTokens>()!.textMuted,
           labelStyle: const TextStyle(fontWeight: FontWeight.bold),
           tabs: const [
             Tab(text: '기록 추가'),

--- a/frontend/lib/src/features/meal_record/presentation/widgets/menu_detail_sheet.dart
+++ b/frontend/lib/src/features/meal_record/presentation/widgets/menu_detail_sheet.dart
@@ -72,7 +72,7 @@ class MenuDetailSheet extends ConsumerWidget {
             width: 40,
             height: 4,
             decoration: BoxDecoration(
-              color: Colors.grey.shade300,
+              color: tokens.divider,
               borderRadius: BorderRadius.circular(2),
             ),
           ),

--- a/frontend/lib/src/features/meal_record/presentation/widgets/menu_register_sheet.dart
+++ b/frontend/lib/src/features/meal_record/presentation/widgets/menu_register_sheet.dart
@@ -164,7 +164,7 @@ class _MenuRegisterSheetState extends ConsumerState<MenuRegisterSheet> {
                 child: Container(
                   width: 40, height: 4,
                   decoration: BoxDecoration(
-                    color: Colors.grey.shade300,
+                    color: tokens.divider,
                     borderRadius: BorderRadius.circular(2),
                   ),
                 ),

--- a/frontend/lib/src/features/meal_record/presentation/widgets/menu_search_field.dart
+++ b/frontend/lib/src/features/meal_record/presentation/widgets/menu_search_field.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/theme/app_theme.dart';
 import '../../data/models/menu_model.dart';
 import '../providers/favorite_provider.dart';
 import '../providers/menu_search_provider.dart';
@@ -256,7 +257,7 @@ class _FavoriteBottomSheet extends StatelessWidget {
               width: 40,
               height: 4,
               decoration: BoxDecoration(
-                color: Colors.grey.shade300,
+                color: Theme.of(context).extension<AppColorTokens>()!.divider,
                 borderRadius: BorderRadius.circular(2),
               ),
             ),

--- a/frontend/lib/src/features/quest/presentation/pages/quest_list_page.dart
+++ b/frontend/lib/src/features/quest/presentation/pages/quest_list_page.dart
@@ -89,9 +89,9 @@ class _QuestList extends ConsumerWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Icon(Icons.assignment_outlined, size: 48, color: Colors.grey),
+            Icon(Icons.assignment_outlined, size: 48, color: tokens.textMuted),
             const SizedBox(height: 16),
-            const Text('진행 중인 퀘스트가 없습니다.', style: TextStyle(color: Colors.grey)),
+            Text('진행 중인 퀘스트가 없습니다.', style: TextStyle(color: tokens.textMuted)),
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () async {

--- a/frontend/lib/src/features/quest/presentation/widgets/quest_item.dart
+++ b/frontend/lib/src/features/quest/presentation/widgets/quest_item.dart
@@ -44,9 +44,9 @@ class QuestItem extends ConsumerWidget {
                   ),
                 ),
                 if (isClaimed)
-                  const Text(
+                  Text(
                     '수령 완료',
-                    style: TextStyle(fontSize: 12, color: Colors.grey, fontWeight: FontWeight.bold),
+                    style: TextStyle(fontSize: 12, color: tokens.textMuted, fontWeight: FontWeight.bold),
                   )
                 else if (isCompleted)
                   const Text(

--- a/frontend/lib/src/features/social/presentation/pages/guestbook_list_page.dart
+++ b/frontend/lib/src/features/social/presentation/pages/guestbook_list_page.dart
@@ -52,7 +52,7 @@ class _GuestbookListPageState extends ConsumerState<GuestbookListPage> {
         child: pagingState.items.isEmpty && pagingState.isLoading
             ? const Center(child: CircularProgressIndicator())
             : pagingState.items.isEmpty
-                ? const Center(child: Text('작성된 방명록이 없습니다.', style: TextStyle(color: Colors.white70)))
+                ? Center(child: Text('작성된 방명록이 없습니다.', style: TextStyle(color: tokens.textMuted)))
                 : ListView.separated(
                     controller: _scrollController,
                     padding: const EdgeInsets.all(20),

--- a/frontend/lib/src/features/social/presentation/pages/social_page.dart
+++ b/frontend/lib/src/features/social/presentation/pages/social_page.dart
@@ -495,11 +495,7 @@ class _RankingTabState extends ConsumerState<_RankingTab> {
                           width: 58,
                           height: 58,
                           decoration: BoxDecoration(
-                            gradient: const LinearGradient(
-                              colors: [Color(0xFFF5E6D3), Color(0xFFE8C89A)],
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                            ),
+                            gradient: tokens.cardHeroGrad,
                             borderRadius: BorderRadius.circular(14),
                           ),
                           child: Center(
@@ -565,11 +561,7 @@ class _RankingTabState extends ConsumerState<_RankingTab> {
                           width: 40,
                           height: 40,
                           decoration: BoxDecoration(
-                            gradient: const LinearGradient(
-                              colors: [Color(0xFFF5E6D3), Color(0xFFE8C89A)],
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                            ),
+                            gradient: tokens.cardHeroGrad,
                             borderRadius: BorderRadius.circular(10),
                           ),
                           child: Center(
@@ -707,11 +699,7 @@ class _RankingTabState extends ConsumerState<_RankingTab> {
                           width: 40,
                           height: 40,
                           decoration: BoxDecoration(
-                            gradient: const LinearGradient(
-                              colors: [Color(0xFFF5E6D3), Color(0xFFE8C89A)],
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                            ),
+                            gradient: tokens.cardHeroGrad,
                             borderRadius: BorderRadius.circular(10),
                           ),
                           child: const Center(


### PR DESCRIPTION
## 요약
다크/라이트 테마 CSS 감사(`docs/superpowers/audits/2026-06-25-theming-audit.md`)의 Critical/High + Medium 항목 수정. 라이트모드 default 사용자에게 직접 영향.

## 커밋
**0393b3c — 라이트 무가독 텍스트 → textMuted (C1/H1-H3)**
- C1: 방명록 빈 상태 `Colors.white70` → `tokens.textMuted` (라이트 크림 위 대비 ~1.05:1 = 무가독 해결)
- H1-H3: 퀘스트 빈상태·퀘스트 아이템·메뉴결정 라벨 `Colors.grey` → `tokens.textMuted` (라이트 대비 ~2.55:1, AA fail 해결)

**88bfd6d — 테마 토큰 정비 (M2/M3/M4)**
- M3: `AppColorTokens`에 `divider` 토큰 신설(다크 warm hairline / 라이트 lightDivider) → 바텀시트 핸들 3곳 `grey.shade300` 교체
- M2: social 순위 아바타 그라데이션 하드코딩(다크 beige) → `tokens.cardHeroGrad` (mode-adaptive)
- M4: meal_record TabBar 미선택 라벨 `Colors.grey` → `tokens.textMuted`

## 검증
- 변경 파일 `flutter analyze` 무경고
- 테마 위젯 테스트(profile_avatar, character_page) 6/6 통과 — divider plumbing 런타임 OK
- 커밋은 surgical (dart format 미적용 — 이 repo 베이스라인이 format-clean 아니라 churn 방지)

## 검증 메모
- 라이트모드 육안 확인 권장: C1 빈 방명록 문구, M2 아바타 peach 배경
- 보류: M1·M5(테마 독립 색 팔레트 중앙화), L 항목

🤖 Generated with [Claude Code](https://claude.com/claude-code)