### PR TITLE
refactor: 캐릭터 상태색 중복 제거 + dead 상수 정리 (감사 M5/M1/L4)

### DIFF
--- a/frontend/lib/src/core/constants/app_constants.dart
+++ b/frontend/lib/src/core/constants/app_constants.dart
@@ -35,8 +35,6 @@ class AppConstants {
   // Colors
   static const Color primaryColor = Colors.orange;
   static const Color accentColor = Colors.deepOrange;
-  static const Color backgroundColor = Colors.white;
-  static const Color surfaceColor = Colors.grey;
   static const Color errorColor = Colors.red;
   static const Color successColor = Colors.green;
 

--- a/frontend/lib/src/core/theme/app_theme.dart
+++ b/frontend/lib/src/core/theme/app_theme.dart
@@ -56,6 +56,8 @@ class AppColors {
   static const Color surfaceDark = Color(0xFF1A1A22);
   static const Color iconDisabled = Color(0x66858585);
   static const Color masterGold = Color(0xFFFFD700);
+  // 항상 밝은 액센트(캐릭터 상태색 등) 위에 올라가는 고정 다크 텍스트/아이콘 색
+  static const Color onLightAccent = Color(0xFF1A1A1A);
 
   // Light Mode Colors
   static const Color lightBackground = Color(0xFFFDF8F2);

--- a/frontend/lib/src/features/character/presentation/pages/character_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/character_page.dart
@@ -285,17 +285,10 @@ class CharacterPage extends ConsumerWidget {
       );
 
   Widget _statePill(CharacterState state, AppColorTokens tokens) {
-    final stateColor = switch (state) {
-      CharacterState.happy => const Color(0xFFFF85A1),
-      CharacterState.hungry => const Color(0xFFFFCC33),
-      CharacterState.starving => const Color(0xFFFF4444),
-      CharacterState.sleeping => const Color(0xFF2D6BFF),
-      CharacterState.normal => const Color(0xFF4CAF50),
-    };
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
       decoration: BoxDecoration(
-        color: stateColor,
+        color: state.indicatorColor,
         borderRadius: BorderRadius.circular(20),
       ),
       child: Text(
@@ -303,7 +296,7 @@ class CharacterPage extends ConsumerWidget {
         style: const TextStyle(
             fontSize: 12,
             fontWeight: FontWeight.w700,
-            color: Color(0xFF1A1A1A)),
+            color: AppColors.onLightAccent),
       ),
     );
   }

--- a/frontend/lib/src/features/home/presentation/pages/home_page.dart
+++ b/frontend/lib/src/features/home/presentation/pages/home_page.dart
@@ -623,14 +623,14 @@ class _HomePageState extends ConsumerState<HomePage> {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Icon(state.icon, size: 11, color: const Color(0xFF1A1A1A)),
+                  Icon(state.icon, size: 11, color: AppColors.onLightAccent),
                   const SizedBox(width: 3),
                   Text(
                     state.label,
                     style: const TextStyle(
                       fontSize: 12,
                       fontWeight: FontWeight.w700,
-                      color: Color(0xFF1A1A1A),
+                      color: AppColors.onLightAccent,
                     ),
                   ),
                 ],


### PR DESCRIPTION
## 요약
테마 감사 잔여 항목 정리. cross-file 색 중복 제거 + dead-code 삭제.

## 변경
- **M5/M1** (`648894f`): `character_page._statePill` 하드코딩 5색 switch → 기존 `CharacterState.indicatorColor` getter 재사용. **잠복 불일치 정정**: sleeping 색이 pill만 `2D6BFF`(파랑)였고 getter 2곳은 `7C4DFF`(보라) → canonical로 통일(home 인디케이터와 일치). M1: 상태칩 위 고정 다크 텍스트 `#1A1A1A` ×3 → `AppColors.onLightAccent` 상수.
- **L4** (`0f101dc`): 미사용 `AppConstants.backgroundColor`(=white)/`surfaceColor`(=grey) 삭제. 전역 참조 0.

## 범위 밖 (YAGNI)
단일 파일 리터럴(보상뱃지·퀘스트 카테고리·알림 아이콘색)은 cross-file 중복 아니라 유지.

## 검증
- `flutter analyze` 무경고 (전체 lib)
- character_page 테스트 2/2 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)