### PR TITLE
fix: 식사 메뉴 라이트/다크 폴리시 (칩 잘림·대비·탭 위계)

### DIFF
--- a/frontend/lib/src/core/theme/app_theme.dart
+++ b/frontend/lib/src/core/theme/app_theme.dart
@@ -414,7 +414,7 @@ class AppTheme {
 
       tabBarTheme: TabBarThemeData(
         labelColor: tokens.primary,
-        unselectedLabelColor: tokens.textSub,
+        unselectedLabelColor: tokens.textMuted,
         indicatorColor: tokens.primary,
       ),
 

--- a/frontend/lib/src/features/meal_record/presentation/pages/meal_record_page.dart
+++ b/frontend/lib/src/features/meal_record/presentation/pages/meal_record_page.dart
@@ -710,7 +710,7 @@ class _MealInputTabState extends ConsumerState<_MealInputTab> {
                       Text(
                         '음식 사진을 추가해보세요',
                         style: TextStyle(
-                          color: tokens.textMuted,
+                          color: tokens.textSub,
                           fontSize: 13,
                           fontWeight: FontWeight.w500,
                         ),
@@ -719,7 +719,7 @@ class _MealInputTabState extends ConsumerState<_MealInputTab> {
                       Text(
                         '(사진을 첨부하고 AI 분석을 수동으로 요청할 수 있습니다)',
                         style: TextStyle(
-                          color: tokens.primary.withValues(alpha: 0.5),
+                          color: tokens.textMuted,
                           fontSize: 11,
                         ),
                       ),
@@ -942,6 +942,7 @@ class _InternalMealTypeSelector extends StatelessWidget {
                 child: ChoiceChip(
                   label: Text(type.label),
                   selected: isSelected,
+                  showCheckmark: false,
                   onSelected: (val) => val ? onChanged(type) : null,
                 ),
               ),

--- a/frontend/lib/src/features/meal_record/presentation/widgets/menu_detail_sheet.dart
+++ b/frontend/lib/src/features/meal_record/presentation/widgets/menu_detail_sheet.dart
@@ -365,12 +365,12 @@ class _GradeChip extends StatelessWidget {
   final String grade;
   const _GradeChip({required this.grade});
 
-  Color get _color {
+  Color _colorOf(BuildContext context) {
     switch (grade) {
       case 'MASTER':  return AppColors.masterGold;
       case 'ARTISAN': return AppColors.orange;
       case 'MANIA':   return AppColors.peach;
-      default:        return AppColors.textTertiary;
+      default:        return Theme.of(context).extension<AppColorTokens>()!.textSub;
     }
   }
 
@@ -385,16 +385,17 @@ class _GradeChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final color = _colorOf(context);
     return Container(
       width: 52,
       height: 52,
       decoration: BoxDecoration(
-        color: _color.withValues(alpha: 0.12),
+        color: color.withValues(alpha: 0.12),
         borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: _color.withValues(alpha: 0.4)),
+        border: Border.all(color: color.withValues(alpha: 0.4)),
       ),
       child: Center(
-        child: Text(_label, style: TextStyle(fontSize: 11, fontWeight: FontWeight.w700, color: _color)),
+        child: Text(_label, style: TextStyle(fontSize: 11, fontWeight: FontWeight.w700, color: color)),
       ),
     );
   }


### PR DESCRIPTION
## 요약
식사 메뉴(식사기록/캘린더/홈 메뉴섹션) 라이트·다크 모드 시각 점검 후 발견한 폴리시 이슈 수정.

배포 백엔드 직결 + Flutter web 릴리스 빌드 + Playwright로 라이트·다크 × 320·390px 스크린샷 캡처해 검증.

## 변경
- **식사시간 칩 잘림 (P2)**: `ChoiceChip(showCheckmark: false)` — 320px 폭에서 선택 시 체크마크가 Expanded 분배폭을 초과해 '간식' 라벨이 잘리던 문제 해결
- **사진 안내문구 대비 (P3)**: 제목 `textMuted→textSub`, 부제 `primary@0.5→textMuted` — 따뜻한 다크 카드 위 저대비 보완
- **상세시트 등급칩 (P3)**: 미상 등급 색을 다크 팔레트 상수(`AppColors.textTertiary`)에서 테마 토큰(`textSub`)으로 변경, 라이트 모드 가독성 확보 (`_color` getter→`_colorOf(context)`)
- **탭 위계 (P3)**: 미선택 라벨 `textSub→textMuted`, 선택/미선택 시각 위계 정리 (전역 TabBar)

## 검증
- `flutter analyze` 무이슈
- 릴리스 재빌드 후 320 다크 '간식' 풀라벨 확인, 사진카드 부제 가독 개선 확인
- 라이트/다크 전반 invisible text·깨진 레이아웃 없음

## 비고
- 캘린더 하단 네비 겹침은 라우트 전환 페인트 아티팩트로 확인됨(실제 버그 아님)
- 모달 시트/기록목록 탭은 정적 감사로 테마 안전 확인 (CanvasKit 탭 자동화 불가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)