### PR TITLE
fix: 식사기록 탭 선택색을 브랜드 주황으로 (#87 후속)

### DIFF
--- a/frontend/lib/src/core/theme/app_theme.dart
+++ b/frontend/lib/src/core/theme/app_theme.dart
@@ -414,7 +414,7 @@ class AppTheme {
 
       tabBarTheme: TabBarThemeData(
         labelColor: tokens.primary,
-        unselectedLabelColor: tokens.textMuted,
+        unselectedLabelColor: tokens.textSub,
         indicatorColor: tokens.primary,
       ),
 

--- a/frontend/lib/src/features/meal_record/presentation/pages/meal_record_page.dart
+++ b/frontend/lib/src/features/meal_record/presentation/pages/meal_record_page.dart
@@ -248,6 +248,7 @@ class _MealRecordPageState extends ConsumerState<MealRecordPage>
 
   @override
   Widget build(BuildContext context) {
+    final tokens = Theme.of(context).extension<AppColorTokens>()!;
     return GradientScaffold(
       appBar: AppBar(
         title: const Text('식사 기록'),
@@ -265,10 +266,9 @@ class _MealRecordPageState extends ConsumerState<MealRecordPage>
         ],
         bottom: TabBar(
           controller: _tabController,
-          indicatorColor: Theme.of(context).primaryColor,
-          labelColor: Theme.of(context).primaryColor,
-          unselectedLabelColor:
-              Theme.of(context).extension<AppColorTokens>()!.textMuted,
+          indicatorColor: tokens.primary,
+          labelColor: tokens.primary,
+          unselectedLabelColor: tokens.textMuted,
           labelStyle: const TextStyle(fontWeight: FontWeight.bold),
           tabs: const [
             Tab(text: '기록 추가'),


### PR DESCRIPTION
## 배경
#87에서 탭 위계 개선으로 전역 `tabBarTheme.unselectedLabelColor`를 바꿨으나, 식사기록 `TabBar`가 인라인으로 색을 오버라이드하고 있어 **실제 화면엔 적용되지 않았음**. 재검증에서 확인.

## 근본 원인
선택 라벨/인디케이터가 `Theme.of(context).primaryColor` 사용 → Material3 다크에서 시드(주황)에서 파생된 **탁한 파스텔톤**으로 렌더 → 미선택보다 흐리게 보임.

## 변경
- 식사기록 TabBar 선택 라벨/인디케이터: `Theme.of(context).primaryColor` → `tokens.primary`(브랜드 주황 #FF7A3D)
- 미선택: `tokens.textMuted` 유지
- 효과 없던 전역 `tabBarTheme` unselected 변경 되돌림 (`textMuted`→`textSub`)

## 검증
- `flutter analyze` 무이슈
- 릴리스 재빌드 + 라이트/다크 × 320/390 재캡처: 선택 '기록 추가' 진한 주황+밑줄로 미선택 대비 뚜렷 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)