### PR TITLE
fix: 캐릭터/프로필 화면 라이트 모드 대응 (다크 팔레트→테마 토큰)

### DIFF
--- a/frontend/lib/src/features/auth/presentation/pages/auth_page.dart
+++ b/frontend/lib/src/features/auth/presentation/pages/auth_page.dart
@@ -123,7 +123,7 @@ class _AuthPageState extends ConsumerState<AuthPage> {
               Text(
                 '음식과 함께 성장하는 캐릭터',
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: AppColors.textSecondary,
+                      color: Theme.of(context).extension<AppColorTokens>()!.textSub,
                     ),
               )
                   .animate()
@@ -147,7 +147,7 @@ class _AuthPageState extends ConsumerState<AuthPage> {
                               style: TextStyle(
                                 fontSize: 16,
                                 fontWeight: FontWeight.w600,
-                                color: _isLogin ? AppColors.orange : AppColors.textSecondary,
+                                color: _isLogin ? AppColors.orange : Theme.of(context).extension<AppColorTokens>()!.textSub,
                               ),
                             ),
                             const SizedBox(height: 8),
@@ -174,7 +174,7 @@ class _AuthPageState extends ConsumerState<AuthPage> {
                               style: TextStyle(
                                 fontSize: 16,
                                 fontWeight: FontWeight.w600,
-                                color: !_isLogin ? AppColors.orange : AppColors.textSecondary,
+                                color: !_isLogin ? AppColors.orange : Theme.of(context).extension<AppColorTokens>()!.textSub,
                               ),
                             ),
                             const SizedBox(height: 8),

--- a/frontend/lib/src/features/character/presentation/pages/character_collection_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/character_collection_page.dart
@@ -55,9 +55,10 @@ class _CollectionCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final tokens = Theme.of(context).extension<AppColorTokens>()!;
     return Container(
       decoration: BoxDecoration(
-        color: AppColors.surface,
+        color: tokens.card,
         borderRadius: BorderRadius.circular(16),
         boxShadow: AppColors.cardShadow,
       ),
@@ -68,10 +69,10 @@ class _CollectionCard extends ConsumerWidget {
             width: 80,
             height: 80,
             decoration: BoxDecoration(
-              color: AppColors.softPeach,
+              color: tokens.primaryBg,
               borderRadius: BorderRadius.circular(20),
             ),
-            child: const Icon(Icons.pets, size: 44, color: AppColors.orange),
+            child: Icon(Icons.pets, size: 44, color: tokens.primary),
           ),
           const SizedBox(height: 8),
           Text(
@@ -79,7 +80,7 @@ class _CollectionCard extends ConsumerWidget {
             style: GoogleFonts.poppins(
               fontSize: 13,
               fontWeight: FontWeight.w600,
-              color: AppColors.textPrimary,
+              color: tokens.textPrimary,
             ),
           ),
           const SizedBox(height: 4),
@@ -87,7 +88,7 @@ class _CollectionCard extends ConsumerWidget {
           const SizedBox(height: 4),
           Text(
             DateFormat('yyyy.MM.dd').format(collection.achievedAt.toLocal()),
-            style: const TextStyle(fontSize: 11, color: AppColors.textTertiary),
+            style: TextStyle(fontSize: 11, color: tokens.textMuted),
           ),
           const SizedBox(height: 8),
           GestureDetector(
@@ -95,15 +96,15 @@ class _CollectionCard extends ConsumerWidget {
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
               decoration: BoxDecoration(
-                color: AppColors.softPeach,
+                color: tokens.primaryBg,
                 borderRadius: BorderRadius.circular(10),
               ),
-              child: const Text(
+              child: Text(
                 '적용',
                 style: TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.w600,
-                  color: AppColors.orange,
+                  color: tokens.primary,
                 ),
               ),
             ),
@@ -168,22 +169,23 @@ class _PartDot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = Theme.of(context).extension<AppColorTokens>()!;
     return Tooltip(
       message: '$tooltip: $value',
       child: Container(
         width: 18,
         height: 18,
         decoration: BoxDecoration(
-          color: AppColors.surfaceElevated,
+          color: tokens.listItemBg,
           borderRadius: BorderRadius.circular(6),
         ),
         child: Center(
           child: Text(
             '$value',
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 10,
               fontWeight: FontWeight.w600,
-              color: AppColors.textSecondary,
+              color: tokens.textSub,
             ),
           ),
         ),
@@ -191,4 +193,3 @@ class _PartDot extends StatelessWidget {
     );
   }
 }
-

--- a/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
@@ -821,15 +821,16 @@ class _TitleCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final acquired = title.acquired;
+    final tokens = Theme.of(context).extension<AppColorTokens>()!;
 
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: AppColors.surface,
+        color: tokens.card,
         borderRadius: BorderRadius.circular(16),
         boxShadow: AppColors.cardShadow,
         border: title.isEquipped
-            ? Border.all(color: AppColors.orange.withValues(alpha: 0.5), width: 1.5)
+            ? Border.all(color: tokens.primary.withValues(alpha: 0.5), width: 1.5)
             : null,
       ),
       child: Row(
@@ -839,15 +840,13 @@ class _TitleCard extends StatelessWidget {
             width: 48,
             height: 48,
             decoration: BoxDecoration(
-              color: acquired
-                  ? AppColors.softPeach
-                  : AppColors.surfaceDark,
+              color: acquired ? tokens.primaryBg : tokens.listItemBg,
               borderRadius: BorderRadius.circular(14),
             ),
             child: Icon(
               Icons.workspace_premium,
               size: 26,
-              color: acquired ? AppColors.orange : AppColors.iconDisabled,
+              color: acquired ? tokens.primary : tokens.textMuted,
             ),
           ),
           const SizedBox(width: 14),
@@ -866,7 +865,7 @@ class _TitleCard extends StatelessWidget {
                         style: TextStyle(
                           fontSize: 15,
                           fontWeight: FontWeight.w600,
-                          color: acquired ? AppColors.textPrimary : AppColors.textTertiary,
+                          color: acquired ? tokens.textPrimary : tokens.textMuted,
                         ),
                       ),
                     ),
@@ -875,15 +874,15 @@ class _TitleCard extends StatelessWidget {
                       Container(
                         padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
                         decoration: BoxDecoration(
-                          color: AppColors.softPeach,
+                          color: tokens.primaryBg,
                           borderRadius: BorderRadius.circular(8),
                         ),
-                        child: const Text(
+                        child: Text(
                           '장착 중',
                           style: TextStyle(
                             fontSize: 10,
                             fontWeight: FontWeight.w600,
-                            color: AppColors.orange,
+                            color: tokens.primary,
                           ),
                         ),
                       ),
@@ -895,18 +894,18 @@ class _TitleCard extends StatelessWidget {
                   title.description,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 12,
-                    color: AppColors.textTertiary,
+                    color: tokens.textMuted,
                   ),
                 ),
                 if (acquired && title.achievedAt != null) ...[
                   const SizedBox(height: 3),
                   Text(
                     DateFormat('yyyy.MM.dd').format(title.achievedAt!.toLocal()),
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 11,
-                      color: AppColors.textTertiary,
+                      color: tokens.textMuted,
                     ),
                   ),
                 ],
@@ -918,7 +917,7 @@ class _TitleCard extends StatelessWidget {
             TextButton(
               onPressed: onEquip,
               style: TextButton.styleFrom(
-                foregroundColor: title.isEquipped ? AppColors.textSecondary : AppColors.orange,
+                foregroundColor: title.isEquipped ? tokens.textSub : tokens.primary,
                 padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
               ),
               child: Text(title.isEquipped ? '해제' : '장착'),

--- a/frontend/lib/src/features/character/presentation/pages/mastery_list_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/mastery_list_page.dart
@@ -56,12 +56,13 @@ class _MasteryCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = Theme.of(context).extension<AppColorTokens>()!;
     return GestureDetector(
       onTap: onTap,
       child: Container(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: AppColors.surface,
+          color: tokens.card,
           borderRadius: BorderRadius.circular(16),
           boxShadow: AppColors.cardShadow,
         ),
@@ -75,18 +76,18 @@ class _MasteryCard extends StatelessWidget {
                 children: [
                   Text(
                     mastery.menuName,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 15,
                       fontWeight: FontWeight.w600,
-                      color: AppColors.textPrimary,
+                      color: tokens.textPrimary,
                     ),
                   ),
                   const SizedBox(height: 4),
                   Text(
                     mastery.menuCategory,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 12,
-                      color: AppColors.textTertiary,
+                      color: tokens.textMuted,
                     ),
                   ),
                 ],
@@ -97,25 +98,24 @@ class _MasteryCard extends StatelessWidget {
               children: [
                 Text(
                   '${mastery.eatCount}회',
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w700,
-                    color: AppColors.orange,
+                    color: tokens.primary,
                   ),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   DateFormat('MM.dd').format(mastery.lastEatenAt.toLocal()),
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 11,
-                    color: AppColors.textTertiary,
+                    color: tokens.textMuted,
                   ),
                 ),
               ],
             ),
             const SizedBox(width: 8),
-            const Icon(Icons.chevron_right,
-                size: 18, color: AppColors.textTertiary),
+            Icon(Icons.chevron_right, size: 18, color: tokens.textMuted),
           ],
         ),
       ),
@@ -127,12 +127,12 @@ class _GradeIcon extends StatelessWidget {
   final String grade;
   const _GradeIcon({required this.grade});
 
-  Color get _color {
+  Color _colorOf(BuildContext context) {
     switch (grade) {
       case 'MASTER':  return AppColors.masterGold;
       case 'ARTISAN': return AppColors.orange;
       case 'MANIA':   return AppColors.peach;
-      default:        return AppColors.textTertiary;
+      default:        return Theme.of(context).extension<AppColorTokens>()!.textSub;
     }
   }
 
@@ -147,13 +147,14 @@ class _GradeIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final color = _colorOf(context);
     return Container(
       width: 52,
       height: 52,
       decoration: BoxDecoration(
-        color: _color.withValues(alpha: 0.12),
+        color: color.withValues(alpha: 0.12),
         borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: _color.withValues(alpha: 0.4)),
+        border: Border.all(color: color.withValues(alpha: 0.4)),
       ),
       child: Center(
         child: Text(
@@ -161,7 +162,7 @@ class _GradeIcon extends StatelessWidget {
           style: TextStyle(
             fontSize: 11,
             fontWeight: FontWeight.w700,
-            color: _color,
+            color: color,
           ),
         ),
       ),

--- a/frontend/lib/src/features/character/presentation/pages/reward_list_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/reward_list_page.dart
@@ -59,6 +59,7 @@ class _RewardGroup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = Theme.of(context).extension<AppColorTokens>()!;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -66,10 +67,10 @@ class _RewardGroup extends StatelessWidget {
           padding: const EdgeInsets.only(bottom: 10),
           child: Text(
             typeLabel,
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 13,
               fontWeight: FontWeight.w600,
-              color: AppColors.textSecondary,
+              color: tokens.textSub,
             ),
           ),
         ),
@@ -148,11 +149,12 @@ class _RewardCard extends ConsumerWidget {
     final slot = reward.renderConfig?.slot;
     final isEquipped =
         char != null && slot != null && char.equipment[slot]?.id == reward.id;
+    final tokens = Theme.of(context).extension<AppColorTokens>()!;
 
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: AppColors.surface,
+        color: tokens.card,
         borderRadius: BorderRadius.circular(16),
         boxShadow: AppColors.cardShadow,
       ),
@@ -162,13 +164,13 @@ class _RewardCard extends ConsumerWidget {
             width: 48,
             height: 48,
             decoration: BoxDecoration(
-              color: acquired ? AppColors.softPeach : AppColors.surfaceDark,
+              color: acquired ? tokens.primaryBg : tokens.listItemBg,
               borderRadius: BorderRadius.circular(14),
             ),
             child: Icon(
               _typeIcon,
               size: 24,
-              color: acquired ? AppColors.orange : AppColors.iconDisabled,
+              color: acquired ? tokens.primary : tokens.textMuted,
             ),
           ),
           const SizedBox(width: 14),
@@ -181,17 +183,15 @@ class _RewardCard extends ConsumerWidget {
                   style: TextStyle(
                     fontSize: 15,
                     fontWeight: FontWeight.w600,
-                    color: acquired
-                        ? AppColors.textPrimary
-                        : AppColors.textTertiary,
+                    color: acquired ? tokens.textPrimary : tokens.textMuted,
                   ),
                 ),
                 const SizedBox(height: 3),
                 Text(
                   reward.description,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 12,
-                    color: AppColors.textTertiary,
+                    color: tokens.textMuted,
                   ),
                 ),
                 if (acquired && reward.achievedAt != null) ...[
@@ -199,9 +199,9 @@ class _RewardCard extends ConsumerWidget {
                   Text(
                     DateFormat('yyyy.MM.dd')
                         .format(reward.achievedAt!.toLocal()),
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 11,
-                      color: AppColors.textTertiary,
+                      color: tokens.textMuted,
                     ),
                   ),
                 ],
@@ -215,8 +215,7 @@ class _RewardCard extends ConsumerWidget {
                 padding:
                     const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
                 decoration: BoxDecoration(
-                  color:
-                      isEquipped ? AppColors.surfaceDark : AppColors.softPeach,
+                  color: isEquipped ? tokens.listItemBg : tokens.primaryBg,
                   borderRadius: BorderRadius.circular(10),
                 ),
                 child: Text(
@@ -224,8 +223,7 @@ class _RewardCard extends ConsumerWidget {
                   style: TextStyle(
                     fontSize: 11,
                     fontWeight: FontWeight.w600,
-                    color:
-                        isEquipped ? AppColors.textSecondary : AppColors.orange,
+                    color: isEquipped ? tokens.textSub : tokens.primary,
                   ),
                 ),
               ),
@@ -234,15 +232,15 @@ class _RewardCard extends ConsumerWidget {
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
               decoration: BoxDecoration(
-                color: AppColors.softPeach,
+                color: tokens.primaryBg,
                 borderRadius: BorderRadius.circular(10),
               ),
-              child: const Text(
+              child: Text(
                 '획득',
                 style: TextStyle(
                   fontSize: 11,
                   fontWeight: FontWeight.w600,
-                  color: AppColors.orange,
+                  color: tokens.primary,
                 ),
               ),
             )
@@ -250,12 +248,12 @@ class _RewardCard extends ConsumerWidget {
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
               decoration: BoxDecoration(
-                color: AppColors.surfaceDark,
+                color: tokens.listItemBg,
                 borderRadius: BorderRadius.circular(10),
               ),
-              child: const Text(
+              child: Text(
                 '미획득',
-                style: TextStyle(fontSize: 11, color: AppColors.textTertiary),
+                style: TextStyle(fontSize: 11, color: tokens.textMuted),
               ),
             ),
         ],

--- a/frontend/lib/src/features/character/presentation/widgets/badge_progress_banner.dart
+++ b/frontend/lib/src/features/character/presentation/widgets/badge_progress_banner.dart
@@ -11,6 +11,7 @@ class BadgeProgressBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = Theme.of(context).extension<AppColorTokens>()!;
     final total = badges.length;
     final unlocked = badges.where((b) => b.isUnlocked).length;
     final percent = total > 0 ? unlocked / total : 0.0;
@@ -28,11 +29,11 @@ class BadgeProgressBanner extends StatelessWidget {
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Text(
+                  Text(
                     '뱃지 달성 현황',
                     style: TextStyle(
                       fontSize: 12,
-                      color: AppColors.textSecondary,
+                      color: tokens.textSub,
                     ),
                   ),
                   const SizedBox(height: 4),
@@ -41,18 +42,18 @@ class BadgeProgressBanner extends StatelessWidget {
                       children: [
                         TextSpan(
                           text: '$unlocked',
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontSize: 28,
                             fontWeight: FontWeight.bold,
-                            color: AppColors.orange,
+                            color: tokens.primary,
                             fontFamily: 'Poppins',
                           ),
                         ),
                         TextSpan(
                           text: ' / $total',
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontSize: 18,
-                            color: AppColors.textSecondary,
+                            color: tokens.textSub,
                             fontFamily: 'Poppins',
                           ),
                         ),
@@ -65,13 +66,13 @@ class BadgeProgressBanner extends StatelessWidget {
                 width: 48,
                 height: 48,
                 decoration: BoxDecoration(
-                  color: AppColors.softPeach,
+                  color: tokens.primaryBg,
                   borderRadius: BorderRadius.circular(14),
                 ),
-                child: const Icon(
+                child: Icon(
                   Icons.military_tech,
                   size: 32,
-                  color: AppColors.orange,
+                  color: tokens.primary,
                 ),
               ),
             ],
@@ -84,16 +85,16 @@ class BadgeProgressBanner extends StatelessWidget {
             children: [
               Text(
                 '총 $total개 중 $unlocked개 획득',
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 11,
-                  color: AppColors.textSecondary,
+                  color: tokens.textSub,
                 ),
               ),
               Text(
                 percentLabel,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 11,
-                  color: AppColors.peach,
+                  color: tokens.primarySoft,
                   fontWeight: FontWeight.w600,
                 ),
               ),

--- a/frontend/lib/src/features/home/presentation/pages/home_page.dart
+++ b/frontend/lib/src/features/home/presentation/pages/home_page.dart
@@ -439,7 +439,7 @@ class _HomePageState extends ConsumerState<HomePage> {
         const SizedBox(width: 4),
         Text(
           label,
-          style: const TextStyle(fontSize: 10, color: AppColors.textSecondary),
+          style: TextStyle(fontSize: 10, color: Theme.of(context).extension<AppColorTokens>()!.textSub),
         ),
       ],
     );

--- a/frontend/lib/src/features/profile/presentation/pages/edit_profile_page.dart
+++ b/frontend/lib/src/features/profile/presentation/pages/edit_profile_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/gradient_scaffold.dart';
+import '../../../../core/theme/app_theme.dart';
 import '../../data/models/user_model.dart';
 import '../providers/user_provider.dart';
 
@@ -139,7 +140,8 @@ class _EditProfilePageState extends ConsumerState<EditProfilePage> {
               runSpacing: 8,
               children: _allergenList.map((allergen) {
                 final isSelected = _selectedAllergies.contains(allergen);
-                final primaryColor = Theme.of(context).primaryColor;
+                final primaryColor =
+                    Theme.of(context).extension<AppColorTokens>()!.primary;
                 return FilterChip(
                   label: Text(allergen),
                   selected: isSelected,

--- a/frontend/lib/src/features/social/presentation/pages/other_profile_page.dart
+++ b/frontend/lib/src/features/social/presentation/pages/other_profile_page.dart
@@ -98,7 +98,7 @@ class _OtherProfilePageState extends ConsumerState<OtherProfilePage> {
                         ),
                       ],
                       const SizedBox(height: 4),
-                      Text('@${user.username}', style: const TextStyle(color: AppColors.textSecondary)),
+                      Text('@${user.username}', style: TextStyle(color: Theme.of(context).extension<AppColorTokens>()!.textSub)),
                       const SizedBox(height: 24),
                       _buildActionButtons(isFriend, isSent, isReceived, user.id, user),
                     ],
@@ -263,7 +263,7 @@ class _GuestbookSection extends ConsumerWidget {
             error: (err, _) => Center(child: Text('오류가 발생했습니다.', style: TextStyle(color: tokens.textMuted))),
             data: (entries) {
               if (entries.isEmpty) {
-                return const Center(child: Padding(padding: EdgeInsets.symmetric(vertical: 20), child: Text('아직 작성된 방명록이 없습니다.', style: TextStyle(color: AppColors.textTertiary))));
+                return Center(child: Padding(padding: const EdgeInsets.symmetric(vertical: 20), child: Text('아직 작성된 방명록이 없습니다.', style: TextStyle(color: tokens.textMuted))));
               }
 
               return ListView.separated(
@@ -356,7 +356,7 @@ class _StatItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Text(label, style: const TextStyle(fontSize: 12, color: AppColors.textSecondary)),
+        Text(label, style: TextStyle(fontSize: 12, color: Theme.of(context).extension<AppColorTokens>()!.textSub)),
         const SizedBox(height: 4),
         Text(value, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
       ],


### PR DESCRIPTION
## 배경
라이트/다크 점검 확대 결과, 캐릭터/프로필 일부 화면이 다크 팔레트 상수(`AppColors.surface`/`textPrimary` 등)를 위젯에 직접 사용 → **라이트 모드에서 카드가 다크로 고정**되거나 텍스트 대비가 낮음. (#85/#86 테마 감사에서 누락된 잔여 부채)

## 실측 (라이트 모드 BEFORE → AFTER)
배포 백엔드 직결 + Playwright로 라이트 모드 캡처:
- 보상 아이템: 다크 카드(흰 텍스트) on 라이트 배경 → **라이트 카드**로 수정
- 먹찌 도감: 다크 카드 → 라이트 카드
- (mastery는 데이터 없어 빈 상태, 코드+analyze 검증)

## 변경 (AppColors 다크 상수 → AppColorTokens)
| 파일 | 내용 |
|---|---|
| `reward_list_page` | 토큰 0 → 전면 토큰화 (카드/텍스트/뱃지) |
| `mastery_list_page` | 동일 + 등급아이콘 미상등급색 토큰화 |
| `character_collection_page` | 동일 |
| `badge_progress_banner` | 텍스트/아이콘 토큰화 |
| `equipment_management_page` | `_TitleCard` 다크 카드/텍스트 토큰화 |
| `edit_profile_page` | 알러지칩 `Theme.of(context).primaryColor`(M3 다크 파스텔) → `tokens.primary` |
| `other_profile_page`, `home_page`, `auth_page` | 잔여 `textSecondary` → `tokens.textSub` |

매핑: `surface/surfaceDark`→`card/listItemBg`, `textPrimary/Secondary/Tertiary`→`textPrimary/textSub/textMuted`, `softPeach`→`primaryBg`, `orange`→`primary`. 브랜드 상수(masterGold/peach/cardShadow)는 유지.

## 검증
- `flutter analyze` 무이슈
- 라이트 BEFORE/AFTER 실측으로 카드 다크 고정 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)