### PR TITLE
refactor: 캐릭터 스테이지 도입 — 배경 테두리 다크모드 이슈 해결

### DIFF
--- a/frontend/lib/src/core/theme/app_theme.dart
+++ b/frontend/lib/src/core/theme/app_theme.dart
@@ -148,17 +148,17 @@ class AppColorTokens extends ThemeExtension<AppColorTokens> {
       end: Alignment.bottomRight,
     ),
     charBgNormal: LinearGradient(
-      colors: [Color(0xFFF5E6D3), Color(0xFFE8C89A)],
+      colors: [Color(0xFF241D15), Color(0xFF16110C)],
       begin: Alignment.topLeft,
       end: Alignment.bottomRight,
     ),
     charBgHungry: LinearGradient(
-      colors: [Color(0xFFF5DFB8), Color(0xFFD9B272)],
+      colors: [Color(0xFF2C2012), Color(0xFF1A130B)],
       begin: Alignment.topLeft,
       end: Alignment.bottomRight,
     ),
     charBgStarving: LinearGradient(
-      colors: [Color(0xFFE6BDB0), Color(0xFFC98878)],
+      colors: [Color(0xFF2C1714), Color(0xFF1A0E0C)],
       begin: Alignment.topLeft,
       end: Alignment.bottomRight,
     ),

--- a/frontend/lib/src/core/widgets/mukzzi_character.dart
+++ b/frontend/lib/src/core/widgets/mukzzi_character.dart
@@ -396,6 +396,8 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
           borderRadius: radius,
           child: Stack(
             children: [
+              // 배경 미장착 시: 빌트인 기본 backdrop(스포트라이트 + 바닥 + 접지 그림자)
+              if (backgroundSpecs.isEmpty) const _DefaultBackdrop(),
               // 배경(장착): Transform 없이 정적, 스테이지에 클립됨
               for (final spec in backgroundSpecs) _buildLayer(spec),
               // 캐릭터 + 비배경 장비: 루프 애니메이션
@@ -493,6 +495,65 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
 }
 
 
+
+/// 배경 미장착 시 스테이지를 채우는 빌트인 기본 backdrop.
+/// 상단 스포트라이트로 빈 헤드룸을 채우고, 바닥 그라데이션 + 발밑 접지
+/// 그림자로 캐릭터를 안착시킨다. ambient 그라데이션 위에 합성된다.
+class _DefaultBackdrop extends StatelessWidget {
+  const _DefaultBackdrop();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Stack(
+      children: [
+        // 상단 소프트 스포트라이트 → 빈 윗공간을 채워 깊이감 부여
+        Positioned.fill(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: RadialGradient(
+                center: Alignment(0, -0.28),
+                radius: 0.95,
+                colors: [Color(0x1FFFFFFF), Color(0x00FFFFFF)],
+              ),
+            ),
+          ),
+        ),
+        // 하단 바닥 그라데이션 → 은은한 받침
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: FractionallySizedBox(
+            heightFactor: 0.42,
+            widthFactor: 1,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [Color(0x00000000), Color(0x1A000000)],
+                ),
+              ),
+            ),
+          ),
+        ),
+        // 발밑 접지 그림자(타원 소프트)
+        Align(
+          alignment: Alignment(0, 0.74),
+          child: FractionallySizedBox(
+            widthFactor: 0.5,
+            heightFactor: 0.07,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: RadialGradient(
+                  colors: [Color(0x2B000000), Color(0x00000000)],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
 
 class _ParticleData {
   final String icon;

--- a/frontend/lib/src/core/widgets/mukzzi_character.dart
+++ b/frontend/lib/src/core/widgets/mukzzi_character.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mukzzi/src/features/character/domain/models/reward_model.dart';
+import 'package:mukzzi/src/core/theme/app_theme.dart';
 
 enum CharacterState { normal, happy, hungry, starving, sleeping }
 
@@ -124,7 +125,6 @@ class MukzziCharacter extends StatelessWidget {
   final bool showAccessory;
   final String? equippedAccessory;
   final Map<EquipmentSlot, RewardModel> equipment;
-  final bool backgroundEdgeFade;
   final bool enableAnimation;
 
   const MukzziCharacter({
@@ -134,7 +134,6 @@ class MukzziCharacter extends StatelessWidget {
     this.showAccessory = false,
     this.equippedAccessory,
     this.equipment = const {},
-    this.backgroundEdgeFade = false,
     this.enableAnimation = false,
   }) : assert(size >= 60,
             'MukzziCharacter: size < 60 renders detail-loss. Use at least 80 for best results.');
@@ -167,7 +166,6 @@ class MukzziCharacter extends StatelessWidget {
       showAccessory: showAccessory,
       equippedAccessory: equippedAccessory,
       equipment: equipment,
-      backgroundEdgeFade: backgroundEdgeFade,
       enableAnimation: enableAnimation,
     );
   }
@@ -179,7 +177,6 @@ class _SvgLayeredCharacter extends StatefulWidget {
   final bool showAccessory;
   final String? equippedAccessory;
   final Map<EquipmentSlot, RewardModel> equipment;
-  final bool backgroundEdgeFade;
   final bool enableAnimation;
 
   const _SvgLayeredCharacter({
@@ -188,7 +185,6 @@ class _SvgLayeredCharacter extends StatefulWidget {
     required this.showAccessory,
     this.equippedAccessory,
     required this.equipment,
-    required this.backgroundEdgeFade,
     required this.enableAnimation,
   });
 
@@ -370,21 +366,48 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
       },
     );
 
+    final tokens = Theme.of(context).extension<AppColorTokens>()!;
+    final ambient = switch (widget.state) {
+      CharacterState.hungry => tokens.charBgHungry,
+      CharacterState.starving => tokens.charBgStarving,
+      _ => tokens.charBgNormal,
+    };
+    final radius = BorderRadius.circular(widget.size * 0.16);
+
+    // 스테이지: 테마·상태별 ambient 받침 + 둥근 클립 + 그림자.
+    // 장착 배경(scene)은 이 클립에 채워져 의도된 "액자"로 렌더되고,
+    // 배경 미장착 시 ambient 받침이 보인다.
     return SizedBox(
       width: widget.size,
       height: widget.size,
-      child: Stack(
-        children: [
-          // 배경: Transform 없이 정적
-          for (final spec in backgroundSpecs) _buildLayer(spec),
-          // 캐릭터 + 비배경 장비: 루프 애니메이션
-          animatedCharacter,
-          _FloatingParticles(
-            state: widget.state,
-            size: widget.size,
-            enableAnimation: widget.enableAnimation,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: ambient,
+          borderRadius: radius,
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x1F000000),
+              blurRadius: 20,
+              offset: Offset(0, 8),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: radius,
+          child: Stack(
+            children: [
+              // 배경(장착): Transform 없이 정적, 스테이지에 클립됨
+              for (final spec in backgroundSpecs) _buildLayer(spec),
+              // 캐릭터 + 비배경 장비: 루프 애니메이션
+              animatedCharacter,
+              _FloatingParticles(
+                state: widget.state,
+                size: widget.size,
+                enableAnimation: widget.enableAnimation,
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
@@ -454,62 +477,7 @@ class _SvgLayeredCharacterState extends State<_SvgLayeredCharacter>
       fit: BoxFit.contain,
     );
 
-    if (isBackground) {
-      // SVG 파일의 배경 rect가 viewBox 밖(-2~1002)으로 블리드되도록 수정됐으므로
-      // 렌더링 경계 anti-alias 픽셀이 뷰박스 안쪽에 생기지 않습니다.
-      // 추가로 가장 바깥 1% 알파를 0으로 만들어 잔여 서브픽셀 번짐을 제거합니다.
-      const edgeColors = [Colors.transparent, Colors.black, Colors.black, Colors.transparent];
-      const edgeStops = [0.0, 0.01, 0.99, 1.0];
-      layer = ShaderMask(
-        shaderCallback: (bounds) => const LinearGradient(
-          begin: Alignment.centerLeft,
-          end: Alignment.centerRight,
-          colors: edgeColors,
-          stops: edgeStops,
-        ).createShader(bounds),
-        blendMode: BlendMode.dstIn,
-        child: ShaderMask(
-          shaderCallback: (bounds) => const LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: edgeColors,
-            stops: edgeStops,
-          ).createShader(bounds),
-          blendMode: BlendMode.dstIn,
-          child: layer,
-        ),
-      );
-    }
-
-    // backgroundEdgeFade 옵션: 중심부까지 소프트하게 페이드
-    if (widget.backgroundEdgeFade && isBackground) {
-      const fadeColors = [
-        Colors.transparent,
-        Colors.black,
-        Colors.black,
-        Colors.transparent,
-      ];
-      const fadeStops = [0.01, 0.16, 0.84, 0.99];
-      layer = ShaderMask(
-        shaderCallback: (bounds) => const LinearGradient(
-          begin: Alignment.centerLeft,
-          end: Alignment.centerRight,
-          colors: fadeColors,
-          stops: fadeStops,
-        ).createShader(bounds),
-        blendMode: BlendMode.dstIn,
-        child: ShaderMask(
-          shaderCallback: (bounds) => const LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: fadeColors,
-            stops: fadeStops,
-          ).createShader(bounds),
-          blendMode: BlendMode.dstIn,
-          child: layer,
-        ),
-      );
-    }
+    // 배경 가장자리는 스테이지 ClipRRect가 크리스프하게 처리(알파 페이드 불필요).
 
     return Positioned.fill(
       child: Transform.translate(

--- a/frontend/lib/src/features/character/presentation/pages/character_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/character_page.dart
@@ -84,7 +84,6 @@ class CharacterPage extends ConsumerWidget {
                 showAccessory: char?.equippedAccessory != null,
                 equippedAccessory: char?.equippedAccessory?.assetUrl,
                 equipment: char?.equipment ?? const {},
-                backgroundEdgeFade: true,
                 enableAnimation: true,
               ),
             ),

--- a/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
+++ b/frontend/lib/src/features/character/presentation/pages/equipment_management_page.dart
@@ -450,7 +450,6 @@ class _CharacterPreview extends StatelessWidget {
         showAccessory: character.equippedAccessory != null,
         equippedAccessory: character.equippedAccessory?.assetUrl,
         equipment: character.equipment,
-        backgroundEdgeFade: true,
         enableAnimation: false,
       ),
     );

--- a/frontend/lib/src/features/home/presentation/pages/home_page.dart
+++ b/frontend/lib/src/features/home/presentation/pages/home_page.dart
@@ -648,7 +648,6 @@ class _HomePageState extends ConsumerState<HomePage> {
             showAccessory: char?.equippedAccessory != null,
             equippedAccessory: char?.equippedAccessory?.assetUrl,
             equipment: char?.equipment ?? const {},
-            backgroundEdgeFade: true,
             enableAnimation: true,
           ),
         ),


### PR DESCRIPTION
## 문제
장착 배경(scene SVG)이 **컨테이너 없이** Stack 레이어로 떠 있고 가장자리 알파를 투명으로 페이드 → 뒤의 raw 스캐폴드가 비침. 밝기 의존적이라 **다크 모드서 밝은 scene(주방 등)이 떠서 경계(seam)가 보였음**.

## 해결 — CharacterStage
`MukzziCharacter` 내부에 스테이지 도입(호출처 3곳 중복 없이 한 곳):
- 둥근 `ClipRRect` + 그림자 + **상태별 ambient 그라데이션**(charBg* 토큰)
- 장착 scene은 스테이지에 **크리스프 클립** → 의도된 "액자/창", 라이트·다크 모두 seam 없음 (아트 그대로, 딤 없음)
- **dead였던 `charBg*` 다크 토큰을 warm-dark로 정비** → 배경 미장착 시 테마 적응 받침
- 불필요해진 알파 edge-fade + `backgroundEdgeFade` 파라미터 제거 (순 -35줄)

## 검증 (라이브 prod, 라이트/다크)
| 케이스 | 결과 |
|---|---|
| 다크 + 주방 배경(admin) | 흐릿한 seam → **크리스프 액자 카드** ✓ |
| 다크 + 배경없음(QA) | warm-dark 받침(테마 적응) ✓ |
| 라이트 + 주방/배경없음 | 액자 카드 / warm-light 받침, 회귀 없음 ✓ |

`flutter analyze` 무이슈.

## 한계
- **어두운 scene 배경**(야경/벚꽃)은 미획득 + DB 지급 차단으로 prod 검증 못 함. 크리스프 클립이라 동일하게 액자로 렌더될 것으로 예상되나 미검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)